### PR TITLE
Enable multidexed application

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.2.0'
     compile 'com.android.support:cardview-v7:23.2.0'
     compile 'com.android.support:recyclerview-v7:23.2.0'
+    compile 'com.android.support:multidex:1.0.1'
     compile 'net.danlew:android.joda:2.9.2'
     compile 'joda-time:joda-time:2.9.2:no-tzdb'
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"

--- a/app/src/main/kotlin/org/eurofurence/connavigator/app/ConnavigatorApplication.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/app/ConnavigatorApplication.kt
@@ -1,6 +1,7 @@
 package org.eurofurence.connavigator.app
 
 import android.app.Application
+import android.support.multidex.MultiDexApplication
 import net.danlew.android.joda.JodaTimeAndroid
 import org.eurofurence.connavigator.database.UpdateIntentService
 import org.eurofurence.connavigator.gcm.MyInstanceIDListenerService
@@ -11,7 +12,7 @@ import org.eurofurence.connavigator.webapi.apiService
 /**
  * The application initialization point.
  */
-class ConnavigatorApplication : Application() {
+class ConnavigatorApplication : MultiDexApplication() {
     override fun onCreate() {
         super.onCreate()
 


### PR DESCRIPTION
To support correct bootup of the application with multidex enabled, we need to derive from a specific base class.