### PR TITLE
Changes to DB robustness

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/Database.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/Database.kt
@@ -65,13 +65,13 @@ class Database(val context: Context) {
             createGson(File(context.cacheDir, "infogroup.db"), InfoGroup::class.java).cachedApiDB()
 
     fun clear() {
-        dateDb.items = emptyList()
-        eventConferenceDayDb.items = emptyList()
-        eventConferenceRoomDb.items = emptyList()
-        eventConferenceTrackDb.items = emptyList()
-        eventEntryDb.items = emptyList()
-        imageDb.items = emptyList()
-        infoDb.items = emptyList()
-        infoGroupDb.items = emptyList()
+        dateDb.delete()
+        eventConferenceDayDb.delete()
+        eventConferenceRoomDb.delete()
+        eventConferenceTrackDb.delete()
+        eventEntryDb.delete()
+        imageDb.delete()
+        infoDb.delete()
+        infoGroupDb.delete()
     }
 }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/store/CachedDB.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/store/CachedDB.kt
@@ -11,6 +11,12 @@ fun <T> DB<T>.cached() = let {
         var cacheTime: Long? = null
         var cache: List<T>? = null
 
+        override fun delete() {
+            it.delete()
+            cacheTime = null
+            cache = null
+        }
+
         /**
          * Returns the time of the backed cache
          */
@@ -49,6 +55,12 @@ fun <T> IDB<T>.cached() = let {
         var cacheTime: Long? = null
 
         var cache: Map<Any, T>? = null
+
+        override fun delete() {
+            it.delete()
+            cacheTime = null
+            cache = null
+        }
 
         /**
          * Returns the time of the backed cache

--- a/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
@@ -10,6 +10,10 @@ import org.eurofurence.connavigator.util.extensions.not
  *
  */
 class SyncIDB<T>(val deleted: (T) -> Boolean, val synced: IDB<T>) : IDB<T>() {
+    override fun delete() {
+        synced.delete()
+    }
+
     override val time: Long?
         get() = synced.time
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/DBExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/DBExtensions.kt
@@ -10,6 +10,10 @@ import org.eurofurence.connavigator.store.cached
  * Uses the [indexer] function to index the database receiver.
  */
 fun <T> DB<T>.indexBy(indexer: (T) -> Any) = object : IDB<T>() {
+    override fun delete() {
+        this@indexBy.delete()
+    }
+
     override fun id(item: T): Any = indexer(item)
 
     override var items: List<T>
@@ -33,6 +37,11 @@ fun <T> DB<T>.indexBy(indexer: (T) -> Any) = object : IDB<T>() {
  */
 infix fun <T, U> IDB<T>.pairWith(second: IDB<U>) =
         object : IDB<Pair<T?, U?>>() {
+            override fun delete() {
+                this@pairWith.delete()
+                second.delete()
+            }
+
             override val time: Long?
                 get() = this@pairWith.time max second.time
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/IOExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/IOExtensions.kt
@@ -26,3 +26,16 @@ fun File.safeOutStream() = BufferedOutputStream(FileOutputStream(this))
  * Opens a stream on the file. Uses the buffering decorator.
  */
 fun File.safeInStream() = BufferedInputStream(FileInputStream(this))
+
+/**
+ * Executes the block for a substitute file, if successful (no
+ * exception thrown), renames the temporary file to the original.
+ * @param block The block to execute
+ */
+fun File.substitute(block: (File) -> Unit) {
+    File.createTempFile(name, ".$extension", parentFile).let {
+        block(it)
+        if (!it.renameTo(this))
+            throw IOException("Error executing substitution block, could not rename")
+    }
+}


### PR DESCRIPTION
The database clearing did not work as intended, since setting the items to empty lists still results in an existing file. This is now replaced. Furthermore are writes to the databases now indirected on a substitute file. If a file is valid when the app starts, the app wont invalidate it.