### PR TITLE
Mock data by changing dates around

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
@@ -58,17 +58,16 @@ class UpdateIntentService(val api: DefaultApi = DefaultApi()) : IntentService("U
 
             // Check for debug. this will change the dates so they work with the current dates
             if (preferences.getBoolean(resources.getString(R.string.debug_date_enabled), false)) {
-                logd { "DEBUG changing dates" }
-                var dates = api.eventConferenceDayGet(oldDate)
-                if (dates.count() == 0)
-                    dates = driver.eventConferenceDayDb.items
+                logd { "Changing dates instead of updating" }
+                var dates = driver.eventConferenceDayDb.items
+
                 val currentDate = DateTime.now()
                 val offset = preferences.getString(resources.getString(R.string.debug_date_setting), "0").toInt()
 
                 for (index in dates.indices) {
                     dates[index].date = currentDate.plusDays(index - offset).toString("yyyy-MM-dd")
                 }
-                driver.eventConferenceDayDb.overwrite(dates)
+                driver.eventConferenceDayDb.syncWith(dates)
             } else {
                 // If the setting is not set we'll just add the regular days
                 driver.eventConferenceDayDb.syncWith(api.eventConferenceDayGet(oldDate))

--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
@@ -3,12 +3,12 @@ package org.eurofurence.connavigator.database
 import android.app.IntentService
 import android.content.Context
 import android.content.Intent
+import android.preference.PreferenceManager
 import android.support.v4.content.LocalBroadcastManager
 import io.swagger.client.api.DefaultApi
-import org.eurofurence.connavigator.util.extensions.booleans
-import org.eurofurence.connavigator.util.extensions.loge
-import org.eurofurence.connavigator.util.extensions.logv
-import org.eurofurence.connavigator.util.extensions.objects
+import org.eurofurence.connavigator.R
+import org.eurofurence.connavigator.util.extensions.*
+import org.joda.time.DateTime
 import java.util.*
 
 /**
@@ -50,11 +50,29 @@ class UpdateIntentService(val api: DefaultApi = DefaultApi()) : IntentService("U
             // Get the current endpoint status and its date
             val endpoint = api.endpointGet()
             val newDate = endpoint.currentDateTimeUtc
+            val preferences = PreferenceManager.getDefaultSharedPreferences(this)
 
             logv("UIS") { "New date on server: $newDate" }
 
             // Update the databases with the new data
-            driver.eventConferenceDayDb.syncWith(api.eventConferenceDayGet(oldDate))
+
+            // Check for debug. this will change the dates so they work with the current dates
+            if (preferences.getBoolean(resources.getString(R.string.debug_date_enabled), false)) {
+                logd { "DEBUG changing dates" }
+                var dates = api.eventConferenceDayGet(oldDate)
+                if (dates.count() == 0)
+                    dates = driver.eventConferenceDayDb.items
+                val currentDate = DateTime.now()
+                val offset = preferences.getString(resources.getString(R.string.debug_date_setting), "0").toInt()
+
+                for (index in dates.indices) {
+                    dates[index].date = currentDate.plusDays(index - offset).toString("yyyy-MM-dd")
+                }
+                driver.eventConferenceDayDb.overwrite(dates)
+            } else {
+                // If the setting is not set we'll just add the regular days
+                driver.eventConferenceDayDb.syncWith(api.eventConferenceDayGet(oldDate))
+            }
             driver.eventConferenceRoomDb.syncWith(api.eventConferenceRoomGet(oldDate))
             driver.eventConferenceTrackDb.syncWith(api.eventConferenceTrackGet(oldDate))
             driver.eventEntryDb.syncWith(api.eventEntryGet(oldDate))

--- a/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
@@ -42,4 +42,8 @@ class SyncIDB<T>(val deleted: (T) -> Boolean, val synced: IDB<T>) : IDB<T>() {
         // If the database does not exist yet, put all that are not deleted
         items = other.filter(!deleted)
     }
+
+    fun overwrite(other: List<T>) = {
+        items = other
+    }
 }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/store/SyncIDB.kt
@@ -42,8 +42,4 @@ class SyncIDB<T>(val deleted: (T) -> Boolean, val synced: IDB<T>) : IDB<T>() {
         // If the database does not exist yet, put all that are not deleted
         items = other.filter(!deleted)
     }
-
-    fun overwrite(other: List<T>) = {
-        items = other
-    }
 }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/tracking/Analytics.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/tracking/Analytics.kt
@@ -40,13 +40,13 @@ class Analytics {
         private fun updateTracking(context: Context, preferences: SharedPreferences) {
             logv { "Updating tracking to new stats" }
             // Set app-level opt out
-            GoogleAnalytics.getInstance(context).appOptOut = preferences.getBoolean(R.string.settings_tag_analytics_enabled.toString(), true)
+            GoogleAnalytics.getInstance(context).appOptOut = preferences.getBoolean(context.resources.getString(R.string.settings_tag_analytics_enabled), true)
 
 
             // Start tracking
             tracker = GoogleAnalytics.getInstance(context).newTracker("UA-76443357-1")
 
-            var interval = preferences.getString(R.string.settings_tag_analytics_interval.toString(), "50")
+            var interval = "50"
 
             try {
                 interval.toDouble()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
@@ -201,7 +201,8 @@ class ActivityRoot : AppCompatActivity(), RootAPI {
             UpdateIntentService.dispatchUpdate(this@ActivityRoot)
         }
 
-        fab.visibility = View.INVISIBLE
+        if (!BuildConfig.DEBUG)
+            fab.visibility = View.INVISIBLE
     }
 
     private fun handleSettings() {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
@@ -79,7 +79,7 @@ class ActivityRoot : AppCompatActivity(), RootAPI {
     }
 
     private fun setupContent() =
-            navigateRoot(FragmentEventsViewpager::class.java)
+            navigateRoot(FragmentEventsViewpager::class.java, true)
 
     override fun onResume() {
         super.onResume()
@@ -125,7 +125,12 @@ class ActivityRoot : AppCompatActivity(), RootAPI {
         toggle.syncState()
     }
 
-    private fun<T : Fragment> navigateRoot(type: Class<T>) {
+    private fun<T : Fragment> navigateRoot(type: Class<T>, useTabs: Boolean = false) {
+        if (useTabs)
+            tabs.visibility = View.VISIBLE
+        else
+            tabs.visibility = View.GONE
+
         // If not already there, navigate with fragment transaction
         if (!type.isInstance(content)) {
 
@@ -143,7 +148,7 @@ class ActivityRoot : AppCompatActivity(), RootAPI {
         navView.setNavigationItemSelectedListener {
             //Handle the ID
             when (it.itemId) {
-                R.id.navEvents -> navigateRoot(FragmentEventsViewpager::class.java)
+                R.id.navEvents -> navigateRoot(FragmentEventsViewpager::class.java, true)
                 R.id.navInfo -> navigateRoot(FragmentViewInfoGroups::class.java)
                 R.id.navDealersDen -> {
                 }

--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -10,7 +10,7 @@
         android:fitsSystemWindows="true"
         tools:context=".ui.ActivityRoot"
         tools:openDrawer="start"
-android:background="@color/backgroundGrey">
+        android:background="@color/backgroundGrey">
 
     <!-- The first level child, handles scrolling et cetera -->
     <android.support.design.widget.CoordinatorLayout
@@ -25,7 +25,8 @@ android:background="@color/backgroundGrey">
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:theme="@style/AppTheme.AppBarOverlay"
-                android:fitsSystemWindows="true">
+                android:fitsSystemWindows="true"
+        android:id="@+id/appbar">
 
             <!-- Toolbar of the app -->
             <android.support.v7.widget.Toolbar
@@ -34,7 +35,6 @@ android:background="@color/backgroundGrey">
                     android:layout_height="wrap_content"
                     android:background="?attr/colorPrimary"
                     android:fitsSystemWindows="true"
-                    app:layout_scrollFlags="scroll|enterAlways"
                     app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
             <android.support.design.widget.TabLayout
@@ -51,7 +51,7 @@ android:background="@color/backgroundGrey">
         <FrameLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingTop="@dimen/toolbar_height"
+                android:layout_marginTop="@dimen/toolbar_height"
                 android:id="@+id/content">
             <!-- Filled by the root activity -->
         </FrameLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="debug_days_to_add">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
+    <string-array name="debug_days_to_add_v">
+        <item>No days</item>
+        <item>1 day</item>
+        <item>2 days</item>
+        <item>3 days</item>
+        <item>4 days</item>
+        <item>5 days</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="room">Room</string>
     <string name="settings_tag_analytics_enabled">analytics_enabled</string>
     <string name="settings_tag_analytics_interval">analytics_enabled</string>
+    <string name="debug_date_enabled">debug_date_enable</string>
+    <string name="debug_date_setting">dabug_date_setting</string>
     <array name="polling_intervals">
         <item>100</item>
         <item>75</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -14,4 +14,19 @@
                 android:entries="@array/polling_intervals"
                 android:defaultValue="50"/>
     </PreferenceCategory>
+    <PreferenceCategory
+            android:title="Debug">
+        <CheckBoxPreference
+                android:key="@string/debug_date_enabled"
+                android:title="Debug event dates"
+                android:summary="Change the dates so that they will correspond to our dates"
+                android:defaultValue="false"/>
+        <ListPreference
+                android:key="@string/debug_date_setting"
+                android:title="Day to offset events by"
+                android:entries="@array/debug_days_to_add_v"
+                android:entryValues="@array/debug_days_to_add"
+                android:defaultValue="0"
+                android:dependency="@string/debug_date_enabled"/>
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
You can now set a mock dating system. On update it will change the current dates in the backend to the current date, including a specified offset. We can now pretend to be at day 1 of the con