### PR TITLE
Image bounds/home view fixes

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewDealer.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewDealer.kt
@@ -399,6 +399,7 @@ class DealerUi : AnkoComponent<ViewGroup> {
                                 backgroundResource = R.color.cardview_dark_background
                                 lparams(matchParent, wrapContent)
                                 scaleType = ImageView.ScaleType.FIT_CENTER
+                                adjustViewBounds = true
                             }
 
                             artPreviewCaption = textView {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvent.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvent.kt
@@ -150,6 +150,8 @@ class EventUi : AnkoComponent<ViewGroup> {
                     poster = photoView {
                         backgroundResource = R.drawable.image_fade
                         imageResource = R.drawable.placeholder_event
+                        scaleType = ImageView.ScaleType.FIT_CENTER
+                        adjustViewBounds = true
                     }.lparams(matchParent, wrapContent)
 
                     verticalLayout {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewHome.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewHome.kt
@@ -25,6 +25,7 @@ import org.eurofurence.connavigator.util.extensions.applyOnRoot
 import org.eurofurence.connavigator.util.extensions.arcProgress
 import org.eurofurence.connavigator.util.v2.plus
 import org.jetbrains.anko.*
+import org.jetbrains.anko.support.v4.nestedScrollView
 import org.joda.time.DateTime
 import org.joda.time.Days
 
@@ -110,7 +111,7 @@ class HomeUi : AnkoComponent<ViewGroup> {
     lateinit var loginWidget: ViewGroup
 
     override fun createView(ui: AnkoContext<ViewGroup>) = with(ui) {
-        scrollView {
+        nestedScrollView {
             lparams(matchParent, matchParent)
             verticalLayout {
                 lparams(matchParent, matchParent)

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfo.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfo.kt
@@ -90,6 +90,7 @@ class InfoUi : AnkoComponent<ViewGroup> {
                 image = photoView {
                     backgroundResource = R.drawable.image_fade
                     scaleType = ImageView.ScaleType.FIT_CENTER
+                    adjustViewBounds = true
                 }.lparams(matchParent, wrapContent)
 
                 title = themedTextView(R.style.AppTheme_Header) {

--- a/app/src/main/res/layout/fview_event.xml
+++ b/app/src/main/res/layout/fview_event.xml
@@ -26,7 +26,8 @@
                     android:contentDescription="Event"
                     android:src="@drawable/placeholder_event"
                     android:background="@drawable/image_fade"
-                    android:scaleType="fitCenter"/>
+                    android:scaleType="fitCenter"
+            android:adjustViewBounds="true"/>
             <LinearLayout android:layout_width="match_parent"
                           android:layout_height="wrap_content"
                           android:background="@color/primaryDarker"


### PR DESCRIPTION
Images in some locations (Dealers, Events, Info) now adjust the view
size to properly make use of the remaining space.

Also uses a fix for scroll views containing recyclers.