### PR TITLE
Default to gone

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvent.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvent.kt
@@ -169,6 +169,7 @@ class EventUi : AnkoComponent<ViewGroup> {
                         imageResource = R.drawable.placeholder_event
                         scaleType = ImageView.ScaleType.FIT_CENTER
                         adjustViewBounds = true
+                        visibility = View.GONE
                     }.lparams(matchParent, wrapContent)
 
                     verticalLayout {

--- a/app/src/main/res/layout/fview_event.xml
+++ b/app/src/main/res/layout/fview_event.xml
@@ -27,7 +27,8 @@
                     android:src="@drawable/placeholder_event"
                     android:background="@drawable/image_fade"
                     android:scaleType="fitCenter"
-            android:adjustViewBounds="true"/>
+                    android:visibility="gone"
+                    android:adjustViewBounds="true"/>
             <LinearLayout android:layout_width="match_parent"
                           android:layout_height="wrap_content"
                           android:background="@color/primaryDarker"


### PR DESCRIPTION
When the tag of the poster is null (as it is by default) it will not
reset the visibility of the poster. Therefore, all events have a poster
image displayed (default banner).