### PR TITLE
Empty back stack

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
@@ -145,6 +145,7 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
 
         // Restore fragments from saved instance state.
         savedInstanceState?.let {
+            supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             setActionBarMode(ActionBarMode.valueOf(it.getString("currentMode")))
 
             if (it.getBoolean("hasContent"))


### PR DESCRIPTION
Back stack is partly restored but in an unorganized manner. This call
removes all items that are on the back stack but not present. Addresses #199 