### PR TITLE
Add loading to state

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
@@ -111,6 +111,10 @@ class ActivityStart : AppCompatActivity(), AnkoLogger, HasDb {
         savedInstanceState?.let {
             ui.analyticalData.isChecked = it.getBoolean("analyticalData")
             ui.performanceData.isChecked = it.getBoolean("performanceData")
+            if (it.getBoolean("loading")) {
+                ui.startLayout.visibility = View.GONE
+                ui.loadingLayout.visibility = View.VISIBLE
+            }
         }
     }
 
@@ -119,6 +123,7 @@ class ActivityStart : AppCompatActivity(), AnkoLogger, HasDb {
 
         outState.putBoolean("analyticalData", ui.analyticalData.isChecked)
         outState.putBoolean("performanceData", ui.performanceData.isChecked)
+        outState.putBoolean("loading", ui.startLayout.visibility == View.GONE)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
The update listener is still fully functional, but the UI is not showing properly. This is addressed by packing the loading state into the saved instance state.
Addresses #198 

