### PR TITLE
Change drawer on nav

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
@@ -176,6 +176,12 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
                         .replace(R.id.content, content, "content")
                         .commitAllowingStateLoss()
 
+                // Set nav drawer item if nav represented content fragment.
+                (content as? NavRepresented)?.let {
+                    navView.setCheckedItem(it.drawerItemId)
+                }
+
+
                 // If details present, add those.
                 if (contentSub != null)
                     supportFragmentManager
@@ -340,11 +346,18 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
             // Pop existing details.
             popDetails()
 
+            val inst = type.newInstance()
+
+            // Set nav drawer item if nav represented content fragment.
+            (inst as? NavRepresented)?.let {
+                navView.setCheckedItem(it.drawerItemId)
+            }
+
             // Add content to content view.
             supportFragmentManager
                     .beginTransaction()
                     .setCustomAnimations(R.anim.abc_fade_in, R.anim.abc_fade_out, R.anim.abc_fade_in, R.anim.abc_fade_out)
-                    .replace(R.id.content, type.newInstance(), "content")
+                    .replace(R.id.content, inst, "content")
                     .commitAllowingStateLoss()
         }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewAbout.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewAbout.kt
@@ -39,7 +39,11 @@ import us.feras.mdv.MarkdownView
 /**
  * Created by David on 28-4-2016.
  */
-class FragmentViewAbout : Fragment(), ContentAPI {
+class FragmentViewAbout : Fragment(), ContentAPI, NavRepresented {
+    override val drawerItemId: Int
+        get() = R.id.navAbout
+
+
     val ui = AboutUi()
     private val attributations = "Google Map\n\nIcons8"
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewDealers.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewDealers.kt
@@ -25,8 +25,10 @@ import org.jetbrains.anko.support.v4.UI
 /**
  * Created by David on 15-5-2016.
  */
-class FragmentViewDealers : Fragment(), ContentAPI, HasDb, AnkoLogger {
+class FragmentViewDealers : Fragment(), ContentAPI, HasDb, AnkoLogger,NavRepresented {
     override val db by lazyLocateDb()
+    override val drawerItemId: Int
+        get() = R.id.navDealersDen
 
     val ui by lazy { DealersUi() }
     var effectiveDealers = emptyList<DealerRecord>()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvents.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewEvents.kt
@@ -27,8 +27,11 @@ import org.jetbrains.anko.support.v4.selector
 /**
  * Created by David on 5/3/2016.
  */
-class FragmentViewEvents : Fragment(), ContentAPI, HasDb {
+class FragmentViewEvents : Fragment(), ContentAPI, HasDb, NavRepresented {
     override val db by lazyLocateDb()
+    override val drawerItemId: Int
+        get() = R.id.navEvents
+
 
     val eventPager: ViewPager by view()
     val eventSearchBar: EditText by view()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuits.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuits.kt
@@ -18,7 +18,10 @@ import org.jetbrains.anko.support.v4.viewPager
 /**
  * Created by requinard on 7/24/17.
  */
-class FragmentViewFursuits : Fragment() {
+class FragmentViewFursuits : Fragment(), NavRepresented {
+    override val drawerItemId: Int
+        get() = R.id.navFursuitGames
+
     val ui = FursuitsUi()
 
     inner class FursuitPagerAdapter : FragmentPagerAdapter(childFragmentManager) {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewHome.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewHome.kt
@@ -33,8 +33,11 @@ import org.joda.time.Days
 /**
  * Created by David on 5/14/2016.
  */
-class FragmentViewHome : Fragment(), ContentAPI, AnkoLogger {
+class FragmentViewHome : Fragment(), ContentAPI, AnkoLogger, NavRepresented {
     val ui by lazy { HomeUi() }
+
+    override val drawerItemId: Int
+        get() = R.id.navHome
 
     val database by lazy { locateDb() }
     var subscriptions = Disposables.empty()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfoGroups.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfoGroups.kt
@@ -26,8 +26,11 @@ import org.eurofurence.connavigator.util.extensions.applyOnRoot
 import org.eurofurence.connavigator.util.v2.get
 import org.jetbrains.anko.*
 
-class FragmentViewInfoGroups : Fragment(), ContentAPI, HasDb {
+class FragmentViewInfoGroups : Fragment(), ContentAPI, HasDb,NavRepresented {
     override val db by lazyLocateDb()
+    override val drawerItemId: Int
+        get() = R.id.navInfo
+
 
     companion object {
         fun <T : Any, U : Any> weave(parents: List<T>, children: Map<T, List<U>>): List<Choice<T, U>> =

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMaps.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMaps.kt
@@ -8,6 +8,7 @@ import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import org.eurofurence.connavigator.R
 import org.eurofurence.connavigator.database.HasDb
 import org.eurofurence.connavigator.database.lazyLocateDb
 import org.eurofurence.connavigator.ui.communication.ContentAPI
@@ -23,9 +24,12 @@ import org.jetbrains.anko.support.v4.viewPager
 /**
  * Created by david on 8/3/16.
  */
-class FragmentViewMaps : Fragment(), ContentAPI, HasDb {
+class FragmentViewMaps : Fragment(), ContentAPI, HasDb,NavRepresented {
+
     val ui by lazy { MapsUi() }
     override val db by lazyLocateDb()
+    override val drawerItemId: Int
+        get() = R.id.navMaps
 
     inner class MapFragmentPagerAdapter(fragmentManager: FragmentManager) : FragmentStatePagerAdapter(fragmentManager) {
         override fun getPageTitle(position: Int) =

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMessageList.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMessageList.kt
@@ -37,7 +37,10 @@ import org.jetbrains.anko.support.v4.UI
 /**
  * Created by requinard on 6/28/17.
  */
-class FragmentViewMessageList : Fragment(), ContentAPI, AnkoLogger, HasDb {
+class FragmentViewMessageList : Fragment(), ContentAPI, AnkoLogger, HasDb,NavRepresented {
+    override val drawerItemId: Int
+        get() = R.id.navMessages
+
     override val db by lazy { locateDb() }
     val ui by lazy { MessagesUi() }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/NavRepresented.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/NavRepresented.kt
@@ -1,0 +1,5 @@
+package org.eurofurence.connavigator.ui
+
+interface NavRepresented {
+    val drawerItemId: Int
+}


### PR DESCRIPTION
Navigation kept the last item checked. This is not sufficient for proper
state restoring. In this commit, items that are assigned into the
content that are represented in the nav drawer, are marked with an
interface that provides the item to select.