### PR TITLE
Wrap linear layout for some reason

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfoGroups.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewInfoGroups.kt
@@ -66,9 +66,11 @@ class FragmentViewInfoGroups : Fragment(), ContentAPI, HasDb {
 class ViewInfoGroupsUi : AnkoComponent<Fragment> {
     override fun createView(ui: AnkoContext<Fragment>) = with(ui) {
         scrollView {
-            verticalLayout {
-                topPadding = dip(10)
-                id = 1
+            relativeLayout {
+                verticalLayout {
+                    topPadding = dip(10)
+                    id = 1
+                }
             }
         }
     }


### PR DESCRIPTION
As per https://stackoverflow.com/questions/33047445/adjust-linearlayout-height-after-dynamic-change-of-child-imageview a relative layout has to be wrapped
around the linear layout. It works for some reason.

Addresses #265 