### PR TITLE
Fix null and state loss

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityRoot.kt
@@ -483,6 +483,8 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
         }
     }
 
+    private var stateSaved = false
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
@@ -497,6 +499,8 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
             outState.putBoolean("hasContentSub", true)
             supportFragmentManager.putFragment(outState, "contentSub", contentSub)
         }
+
+        stateSaved = true
     }
 
     override fun navigateToEvent(event: EventRecord) {
@@ -548,7 +552,10 @@ class ActivityRoot : AppCompatActivity(), RootAPI, SharedPreferences.OnSharedPre
     }
 
     override fun popDetails() {
-        supportFragmentManager.popBackStack("contentSubAdded", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        // Pop the backstack including the details fragment, unless state is already saved.
+        supportFragmentManager
+                .takeUnless { stateSaved }
+                ?.popBackStack("contentSubAdded", FragmentManager.POP_BACK_STACK_INCLUSIVE)
     }
 
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoGroupFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoGroupFragment.kt
@@ -31,7 +31,7 @@ import java.util.*
 /**
  * Renders an info group element and displays it's individual items
  */
-class InfoGroupFragment : Fragment(), HasDb, ContentAPI {
+class InfoGroupFragment : Fragment(), HasDb, ContentAPI, AnkoLogger {
     inner class InfoItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val layout: LinearLayout by view("layout")
         val name: TextView by view("title")
@@ -56,7 +56,7 @@ class InfoGroupFragment : Fragment(), HasDb, ContentAPI {
     override val db by lazyLocateDb()
 
     private val infoGroupId: UUID? get() = UUID.fromString(arguments.getString("id"))
-    private val infoGroup by lazy { db.knowledgeGroups[infoGroupId]!! }
+    private val infoGroup by lazy { db.knowledgeGroups[infoGroupId] }
 
     val infoItems by lazy {
         db.knowledgeEntries.items
@@ -87,16 +87,21 @@ class InfoGroupFragment : Fragment(), HasDb, ContentAPI {
 
     private fun fillUi() {
         ui.apply {
-            title.text = infoGroup.name
-            mainIcon.text = infoGroup.fontAwesomeIconCharacterUnicodeAddress?.toUnicode() ?: ""
-            description.text = infoGroup.description
-            groupLayout.setOnClickListener {
-                setDropdown()
-            }
-            recycler.apply {
-                adapter = DataAdapter()
-                layoutManager = NonScrollingLinearLayout(context)
-                itemAnimator = DefaultItemAnimator()
+            infoGroup?.let {
+                title.text = it.name
+                mainIcon.text = it.fontAwesomeIconCharacterUnicodeAddress?.toUnicode() ?: ""
+                description.text = it.description
+                groupLayout.setOnClickListener {
+                    setDropdown()
+                }
+                recycler.apply {
+                    adapter = DataAdapter()
+                    layoutManager = NonScrollingLinearLayout(context)
+                    itemAnimator = DefaultItemAnimator()
+                }
+            } ?: run {
+                warn { "Info group initialized on non-existent ID." }
+                groupLayout.visibility = View.GONE
             }
         }
     }


### PR DESCRIPTION
Back stack popping does not allow state loss, so we need to manually
check. Also, info groups might be null and assertion did not recognize
the fact.

Addresses Firebase crashes.