### PR TITLE
Convention Identifier Introduction

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,9 @@ android {
         versionCode 99
         versionName "2.2.9"
         multiDexEnabled true
+
+        buildConfigField "String", "API_BASE_URL", '"https://app.eurofurence.org"'
+        buildConfigField "String", "CONVENTION_IDENTIFIER", '"EF25"'
     }
 
     dexOptions {
@@ -85,7 +88,7 @@ android {
 
 ext {
     // Location of the schema file
-    schema_location = "https://app.eurofurence.org:40000/swagger/v2/swagger.json"
+    schema_location = "https://app.eurofurence.org/EF25/swagger/api/swagger.json"
 
     // Dependency versions
     swagger_annotations_version = "1.5.0"

--- a/app/docs/AggregatedDeltaResponse.md
+++ b/app/docs/AggregatedDeltaResponse.md
@@ -4,6 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**conventionIdentifier** | **String** |  |  [optional]
 **since** | [**Date**](Date.md) |  |  [optional]
 **currentDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
 **events** | [**DeltaResponseEventRecord**](DeltaResponseEventRecord.md) |  |  [optional]

--- a/app/docs/AnnouncementRecord.md
+++ b/app/docs/AnnouncementRecord.md
@@ -4,10 +4,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
-**validFromDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**validUntilDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
+**validFromDateTimeUtc** | [**Date**](Date.md) |  | 
+**validUntilDateTimeUtc** | [**Date**](Date.md) |  | 
 **area** | **String** |  | 
 **author** | **String** |  | 
 **title** | **String** |  | 

--- a/app/docs/AnnouncementsApi.md
+++ b/app/docs/AnnouncementsApi.md
@@ -4,17 +4,17 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2AnnouncementsByIdDelete**](AnnouncementsApi.md#apiV2AnnouncementsByIdDelete) | **DELETE** /Api/v2/Announcements/{Id} | 
-[**apiV2AnnouncementsByIdGet**](AnnouncementsApi.md#apiV2AnnouncementsByIdGet) | **GET** /Api/v2/Announcements/{Id} | Retrieve a single announcement.
-[**apiV2AnnouncementsDelete**](AnnouncementsApi.md#apiV2AnnouncementsDelete) | **DELETE** /Api/v2/Announcements | 
-[**apiV2AnnouncementsGet**](AnnouncementsApi.md#apiV2AnnouncementsGet) | **GET** /Api/v2/Announcements | Retrieves a list of all announcement entries.
-[**apiV2AnnouncementsPost**](AnnouncementsApi.md#apiV2AnnouncementsPost) | **POST** /Api/v2/Announcements | 
-[**apiV2AnnouncementsPut**](AnnouncementsApi.md#apiV2AnnouncementsPut) | **PUT** /Api/v2/Announcements | 
+[**apiAnnouncementsByIdDelete**](AnnouncementsApi.md#apiAnnouncementsByIdDelete) | **DELETE** /Api/Announcements/{Id} | 
+[**apiAnnouncementsByIdGet**](AnnouncementsApi.md#apiAnnouncementsByIdGet) | **GET** /Api/Announcements/{Id} | Retrieve a single announcement.
+[**apiAnnouncementsDelete**](AnnouncementsApi.md#apiAnnouncementsDelete) | **DELETE** /Api/Announcements | 
+[**apiAnnouncementsGet**](AnnouncementsApi.md#apiAnnouncementsGet) | **GET** /Api/Announcements | Retrieves a list of all announcement entries.
+[**apiAnnouncementsPost**](AnnouncementsApi.md#apiAnnouncementsPost) | **POST** /Api/Announcements | 
+[**apiAnnouncementsPut**](AnnouncementsApi.md#apiAnnouncementsPut) | **PUT** /Api/Announcements | 
 
 
-<a name="apiV2AnnouncementsByIdDelete"></a>
-# **apiV2AnnouncementsByIdDelete**
-> apiV2AnnouncementsByIdDelete(id)
+<a name="apiAnnouncementsByIdDelete"></a>
+# **apiAnnouncementsByIdDelete**
+> apiAnnouncementsByIdDelete(id)
 
 
 
@@ -28,9 +28,9 @@ Method | HTTP request | Description
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 UUID id = new UUID(); // UUID | 
 try {
-    apiInstance.apiV2AnnouncementsByIdDelete(id);
+    apiInstance.apiAnnouncementsByIdDelete(id);
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsByIdDelete");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsByIdDelete");
     e.printStackTrace();
 }
 ```
@@ -54,9 +54,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2AnnouncementsByIdGet"></a>
-# **apiV2AnnouncementsByIdGet**
-> AnnouncementRecord apiV2AnnouncementsByIdGet(id)
+<a name="apiAnnouncementsByIdGet"></a>
+# **apiAnnouncementsByIdGet**
+> AnnouncementRecord apiAnnouncementsByIdGet(id)
 
 Retrieve a single announcement.
 
@@ -68,10 +68,10 @@ Retrieve a single announcement.
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    AnnouncementRecord result = apiInstance.apiV2AnnouncementsByIdGet(id);
+    AnnouncementRecord result = apiInstance.apiAnnouncementsByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsByIdGet");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsByIdGet");
     e.printStackTrace();
 }
 ```
@@ -95,9 +95,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2AnnouncementsDelete"></a>
-# **apiV2AnnouncementsDelete**
-> apiV2AnnouncementsDelete()
+<a name="apiAnnouncementsDelete"></a>
+# **apiAnnouncementsDelete**
+> apiAnnouncementsDelete()
 
 
 
@@ -110,9 +110,9 @@ No authorization required
 
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 try {
-    apiInstance.apiV2AnnouncementsDelete();
+    apiInstance.apiAnnouncementsDelete();
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsDelete");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsDelete");
     e.printStackTrace();
 }
 ```
@@ -133,9 +133,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2AnnouncementsGet"></a>
-# **apiV2AnnouncementsGet**
-> List&lt;AnnouncementRecord&gt; apiV2AnnouncementsGet()
+<a name="apiAnnouncementsGet"></a>
+# **apiAnnouncementsGet**
+> List&lt;AnnouncementRecord&gt; apiAnnouncementsGet()
 
 Retrieves a list of all announcement entries.
 
@@ -146,10 +146,10 @@ Retrieves a list of all announcement entries.
 
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 try {
-    List<AnnouncementRecord> result = apiInstance.apiV2AnnouncementsGet();
+    List<AnnouncementRecord> result = apiInstance.apiAnnouncementsGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsGet");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsGet");
     e.printStackTrace();
 }
 ```
@@ -170,9 +170,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2AnnouncementsPost"></a>
-# **apiV2AnnouncementsPost**
-> apiV2AnnouncementsPost(record)
+<a name="apiAnnouncementsPost"></a>
+# **apiAnnouncementsPost**
+> apiAnnouncementsPost(record)
 
 
 
@@ -186,9 +186,9 @@ No authorization required
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 AnnouncementRecord record = new AnnouncementRecord(); // AnnouncementRecord | 
 try {
-    apiInstance.apiV2AnnouncementsPost(record);
+    apiInstance.apiAnnouncementsPost(record);
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsPost");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsPost");
     e.printStackTrace();
 }
 ```
@@ -212,9 +212,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: Not defined
 
-<a name="apiV2AnnouncementsPut"></a>
-# **apiV2AnnouncementsPut**
-> apiV2AnnouncementsPut(record)
+<a name="apiAnnouncementsPut"></a>
+# **apiAnnouncementsPut**
+> apiAnnouncementsPut(record)
 
 
 
@@ -228,9 +228,9 @@ null (empty response body)
 AnnouncementsApi apiInstance = new AnnouncementsApi();
 AnnouncementRecord record = new AnnouncementRecord(); // AnnouncementRecord | 
 try {
-    apiInstance.apiV2AnnouncementsPut(record);
+    apiInstance.apiAnnouncementsPut(record);
 } catch (ApiException e) {
-    System.err.println("Exception when calling AnnouncementsApi#apiV2AnnouncementsPut");
+    System.err.println("Exception when calling AnnouncementsApi#apiAnnouncementsPut");
     e.printStackTrace();
 }
 ```

--- a/app/docs/ArtShowApi.md
+++ b/app/docs/ArtShowApi.md
@@ -4,14 +4,14 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2ArtShowItemActivitesLogPost**](ArtShowApi.md#apiV2ArtShowItemActivitesLogPost) | **POST** /Api/v2/ArtShow/ItemActivites/Log | 
-[**apiV2ArtShowItemActivitesNotificationBundlesSendPost**](ArtShowApi.md#apiV2ArtShowItemActivitesNotificationBundlesSendPost) | **POST** /Api/v2/ArtShow/ItemActivites/NotificationBundles/Send | 
-[**apiV2ArtShowItemActivitesNotificationBundlesSimulationGet**](ArtShowApi.md#apiV2ArtShowItemActivitesNotificationBundlesSimulationGet) | **GET** /Api/v2/ArtShow/ItemActivites/NotificationBundles/Simulation | 
+[**apiArtShowItemActivitesLogPost**](ArtShowApi.md#apiArtShowItemActivitesLogPost) | **POST** /Api/ArtShow/ItemActivites/Log | 
+[**apiArtShowItemActivitesNotificationBundlesSendPost**](ArtShowApi.md#apiArtShowItemActivitesNotificationBundlesSendPost) | **POST** /Api/ArtShow/ItemActivites/NotificationBundles/Send | 
+[**apiArtShowItemActivitesNotificationBundlesSimulationGet**](ArtShowApi.md#apiArtShowItemActivitesNotificationBundlesSimulationGet) | **GET** /Api/ArtShow/ItemActivites/NotificationBundles/Simulation | 
 
 
-<a name="apiV2ArtShowItemActivitesLogPost"></a>
-# **apiV2ArtShowItemActivitesLogPost**
-> apiV2ArtShowItemActivitesLogPost(payload)
+<a name="apiArtShowItemActivitesLogPost"></a>
+# **apiArtShowItemActivitesLogPost**
+> apiArtShowItemActivitesLogPost(payload)
 
 
 
@@ -25,9 +25,9 @@ Method | HTTP request | Description
 ArtShowApi apiInstance = new ArtShowApi();
 byte[] payload = BINARY_DATA_HERE; // byte[] | Art show log contents
 try {
-    apiInstance.apiV2ArtShowItemActivitesLogPost(payload);
+    apiInstance.apiArtShowItemActivitesLogPost(payload);
 } catch (ApiException e) {
-    System.err.println("Exception when calling ArtShowApi#apiV2ArtShowItemActivitesLogPost");
+    System.err.println("Exception when calling ArtShowApi#apiArtShowItemActivitesLogPost");
     e.printStackTrace();
 }
 ```
@@ -51,9 +51,9 @@ null (empty response body)
  - **Content-Type**: application/octet-stream
  - **Accept**: Not defined
 
-<a name="apiV2ArtShowItemActivitesNotificationBundlesSendPost"></a>
-# **apiV2ArtShowItemActivitesNotificationBundlesSendPost**
-> apiV2ArtShowItemActivitesNotificationBundlesSendPost()
+<a name="apiArtShowItemActivitesNotificationBundlesSendPost"></a>
+# **apiArtShowItemActivitesNotificationBundlesSendPost**
+> apiArtShowItemActivitesNotificationBundlesSendPost()
 
 
 
@@ -66,9 +66,9 @@ null (empty response body)
 
 ArtShowApi apiInstance = new ArtShowApi();
 try {
-    apiInstance.apiV2ArtShowItemActivitesNotificationBundlesSendPost();
+    apiInstance.apiArtShowItemActivitesNotificationBundlesSendPost();
 } catch (ApiException e) {
-    System.err.println("Exception when calling ArtShowApi#apiV2ArtShowItemActivitesNotificationBundlesSendPost");
+    System.err.println("Exception when calling ArtShowApi#apiArtShowItemActivitesNotificationBundlesSendPost");
     e.printStackTrace();
 }
 ```
@@ -89,9 +89,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2ArtShowItemActivitesNotificationBundlesSimulationGet"></a>
-# **apiV2ArtShowItemActivitesNotificationBundlesSimulationGet**
-> apiV2ArtShowItemActivitesNotificationBundlesSimulationGet()
+<a name="apiArtShowItemActivitesNotificationBundlesSimulationGet"></a>
+# **apiArtShowItemActivitesNotificationBundlesSimulationGet**
+> apiArtShowItemActivitesNotificationBundlesSimulationGet()
 
 
 
@@ -104,9 +104,9 @@ null (empty response body)
 
 ArtShowApi apiInstance = new ArtShowApi();
 try {
-    apiInstance.apiV2ArtShowItemActivitesNotificationBundlesSimulationGet();
+    apiInstance.apiArtShowItemActivitesNotificationBundlesSimulationGet();
 } catch (ApiException e) {
-    System.err.println("Exception when calling ArtShowApi#apiV2ArtShowItemActivitesNotificationBundlesSimulationGet");
+    System.err.println("Exception when calling ArtShowApi#apiArtShowItemActivitesNotificationBundlesSimulationGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/CommunicationApi.md
+++ b/app/docs/CommunicationApi.md
@@ -4,15 +4,16 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2CommunicationPrivateMessagesByMessageIdReadPost**](CommunicationApi.md#apiV2CommunicationPrivateMessagesByMessageIdReadPost) | **POST** /Api/v2/Communication/PrivateMessages/{MessageId}/Read | Marks a given private message as read (reading receipt).
-[**apiV2CommunicationPrivateMessagesByMessageIdStatusGet**](CommunicationApi.md#apiV2CommunicationPrivateMessagesByMessageIdStatusGet) | **GET** /Api/v2/Communication/PrivateMessages/{MessageId}/Status | 
-[**apiV2CommunicationPrivateMessagesGet**](CommunicationApi.md#apiV2CommunicationPrivateMessagesGet) | **GET** /Api/v2/Communication/PrivateMessages | Retrieves all private messages of an authenticated attendee.
-[**apiV2CommunicationPrivateMessagesPost**](CommunicationApi.md#apiV2CommunicationPrivateMessagesPost) | **POST** /Api/v2/Communication/PrivateMessages | Sends a private message to a specific recipient/attendee.
+[**apiCommunicationPrivateMessagesByMessageIdReadPost**](CommunicationApi.md#apiCommunicationPrivateMessagesByMessageIdReadPost) | **POST** /Api/Communication/PrivateMessages/{MessageId}/Read | Marks a given private message as read (reading receipt).
+[**apiCommunicationPrivateMessagesByMessageIdStatusGet**](CommunicationApi.md#apiCommunicationPrivateMessagesByMessageIdStatusGet) | **GET** /Api/Communication/PrivateMessages/{MessageId}/Status | 
+[**apiCommunicationPrivateMessagesGet**](CommunicationApi.md#apiCommunicationPrivateMessagesGet) | **GET** /Api/Communication/PrivateMessages | Retrieves all private messages of an authenticated attendee.
+[**apiCommunicationPrivateMessagesPost**](CommunicationApi.md#apiCommunicationPrivateMessagesPost) | **POST** /Api/Communication/PrivateMessages | Sends a private message to a specific recipient/attendee.
+[**apiCommunicationPrivateMessagesSentByMeGet**](CommunicationApi.md#apiCommunicationPrivateMessagesSentByMeGet) | **GET** /Api/Communication/PrivateMessages/:sent-by-me | 
 
 
-<a name="apiV2CommunicationPrivateMessagesByMessageIdReadPost"></a>
-# **apiV2CommunicationPrivateMessagesByMessageIdReadPost**
-> Date apiV2CommunicationPrivateMessagesByMessageIdReadPost(messageId, isRead)
+<a name="apiCommunicationPrivateMessagesByMessageIdReadPost"></a>
+# **apiCommunicationPrivateMessagesByMessageIdReadPost**
+> Date apiCommunicationPrivateMessagesByMessageIdReadPost(messageId, isRead)
 
 Marks a given private message as read (reading receipt).
 
@@ -25,12 +26,12 @@ Marks a given private message as read (reading receipt).
 
 CommunicationApi apiInstance = new CommunicationApi();
 UUID messageId = new UUID(); // UUID | `Id` of the message to mark as read
-Boolean isRead = true; // Boolean | 
+Boolean isRead = true; // Boolean | boolean, expected to be 'true' always
 try {
-    Date result = apiInstance.apiV2CommunicationPrivateMessagesByMessageIdReadPost(messageId, isRead);
+    Date result = apiInstance.apiCommunicationPrivateMessagesByMessageIdReadPost(messageId, isRead);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling CommunicationApi#apiV2CommunicationPrivateMessagesByMessageIdReadPost");
+    System.err.println("Exception when calling CommunicationApi#apiCommunicationPrivateMessagesByMessageIdReadPost");
     e.printStackTrace();
 }
 ```
@@ -40,7 +41,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **messageId** | [**UUID**](.md)| &#x60;Id&#x60; of the message to mark as read |
- **isRead** | **Boolean**|  | [optional]
+ **isRead** | **Boolean**| boolean, expected to be &#39;true&#39; always | [optional]
 
 ### Return type
 
@@ -55,9 +56,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2CommunicationPrivateMessagesByMessageIdStatusGet"></a>
-# **apiV2CommunicationPrivateMessagesByMessageIdStatusGet**
-> PrivateMessageStatus apiV2CommunicationPrivateMessagesByMessageIdStatusGet(messageId)
+<a name="apiCommunicationPrivateMessagesByMessageIdStatusGet"></a>
+# **apiCommunicationPrivateMessagesByMessageIdStatusGet**
+> PrivateMessageStatus apiCommunicationPrivateMessagesByMessageIdStatusGet(messageId)
 
 
 
@@ -71,10 +72,10 @@ Name | Type | Description  | Notes
 CommunicationApi apiInstance = new CommunicationApi();
 UUID messageId = new UUID(); // UUID | 
 try {
-    PrivateMessageStatus result = apiInstance.apiV2CommunicationPrivateMessagesByMessageIdStatusGet(messageId);
+    PrivateMessageStatus result = apiInstance.apiCommunicationPrivateMessagesByMessageIdStatusGet(messageId);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling CommunicationApi#apiV2CommunicationPrivateMessagesByMessageIdStatusGet");
+    System.err.println("Exception when calling CommunicationApi#apiCommunicationPrivateMessagesByMessageIdStatusGet");
     e.printStackTrace();
 }
 ```
@@ -98,9 +99,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2CommunicationPrivateMessagesGet"></a>
-# **apiV2CommunicationPrivateMessagesGet**
-> List&lt;PrivateMessageRecord&gt; apiV2CommunicationPrivateMessagesGet()
+<a name="apiCommunicationPrivateMessagesGet"></a>
+# **apiCommunicationPrivateMessagesGet**
+> List&lt;PrivateMessageRecord&gt; apiCommunicationPrivateMessagesGet()
 
 Retrieves all private messages of an authenticated attendee.
 
@@ -113,10 +114,10 @@ Retrieves all private messages of an authenticated attendee.
 
 CommunicationApi apiInstance = new CommunicationApi();
 try {
-    List<PrivateMessageRecord> result = apiInstance.apiV2CommunicationPrivateMessagesGet();
+    List<PrivateMessageRecord> result = apiInstance.apiCommunicationPrivateMessagesGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling CommunicationApi#apiV2CommunicationPrivateMessagesGet");
+    System.err.println("Exception when calling CommunicationApi#apiCommunicationPrivateMessagesGet");
     e.printStackTrace();
 }
 ```
@@ -137,9 +138,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2CommunicationPrivateMessagesPost"></a>
-# **apiV2CommunicationPrivateMessagesPost**
-> UUID apiV2CommunicationPrivateMessagesPost(request)
+<a name="apiCommunicationPrivateMessagesPost"></a>
+# **apiCommunicationPrivateMessagesPost**
+> UUID apiCommunicationPrivateMessagesPost(request)
 
 Sends a private message to a specific recipient/attendee.
 
@@ -153,10 +154,10 @@ Sends a private message to a specific recipient/attendee.
 CommunicationApi apiInstance = new CommunicationApi();
 SendPrivateMessageRequest request = new SendPrivateMessageRequest(); // SendPrivateMessageRequest | 
 try {
-    UUID result = apiInstance.apiV2CommunicationPrivateMessagesPost(request);
+    UUID result = apiInstance.apiCommunicationPrivateMessagesPost(request);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling CommunicationApi#apiV2CommunicationPrivateMessagesPost");
+    System.err.println("Exception when calling CommunicationApi#apiCommunicationPrivateMessagesPost");
     e.printStackTrace();
 }
 ```
@@ -178,5 +179,44 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
+ - **Accept**: text/plain, application/json, text/json
+
+<a name="apiCommunicationPrivateMessagesSentByMeGet"></a>
+# **apiCommunicationPrivateMessagesSentByMeGet**
+> List&lt;PrivateMessageRecord&gt; apiCommunicationPrivateMessagesSentByMeGet()
+
+
+
+  * Requires authorization   
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.api.CommunicationApi;
+
+CommunicationApi apiInstance = new CommunicationApi();
+try {
+    List<PrivateMessageRecord> result = apiInstance.apiCommunicationPrivateMessagesSentByMeGet();
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling CommunicationApi#apiCommunicationPrivateMessagesSentByMeGet");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**List&lt;PrivateMessageRecord&gt;**](PrivateMessageRecord.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 

--- a/app/docs/DealerRecord.md
+++ b/app/docs/DealerRecord.md
@@ -4,9 +4,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
-**registrationNumber** | **Integer** | Registration number (as on badge) of the attendee that acts on behalf/represents this dealer. |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
+**registrationNumber** | **Integer** | Registration number (as on badge) of the attendee that acts on behalf/represents this dealer. | 
 **attendeeNickname** | **String** | Nickname number (as on badge) of the attendee that acts on behalf/represents this dealer. | 
 **displayName** | **String** | **(pba)** Name under which this dealer is acting, e.G. name of the company or brand. | 
 **merchandise** | **String** | **(pba)** Brief description of merchandise/services offered. | 

--- a/app/docs/DealersApi.md
+++ b/app/docs/DealersApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2DealersByIdGet**](DealersApi.md#apiV2DealersByIdGet) | **GET** /Api/v2/Dealers/{Id} | Retrieve a single dealer.
-[**apiV2DealersGet**](DealersApi.md#apiV2DealersGet) | **GET** /Api/v2/Dealers | Retrieves a list of all dealer entries.
+[**apiDealersByIdGet**](DealersApi.md#apiDealersByIdGet) | **GET** /Api/Dealers/{Id} | Retrieve a single dealer.
+[**apiDealersGet**](DealersApi.md#apiDealersGet) | **GET** /Api/Dealers | Retrieves a list of all dealer entries.
 
 
-<a name="apiV2DealersByIdGet"></a>
-# **apiV2DealersByIdGet**
-> DealerRecord apiV2DealersByIdGet(id)
+<a name="apiDealersByIdGet"></a>
+# **apiDealersByIdGet**
+> DealerRecord apiDealersByIdGet(id)
 
 Retrieve a single dealer.
 
@@ -22,10 +22,10 @@ Retrieve a single dealer.
 DealersApi apiInstance = new DealersApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    DealerRecord result = apiInstance.apiV2DealersByIdGet(id);
+    DealerRecord result = apiInstance.apiDealersByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling DealersApi#apiV2DealersByIdGet");
+    System.err.println("Exception when calling DealersApi#apiDealersByIdGet");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2DealersGet"></a>
-# **apiV2DealersGet**
-> List&lt;DealerRecord&gt; apiV2DealersGet()
+<a name="apiDealersGet"></a>
+# **apiDealersGet**
+> List&lt;DealerRecord&gt; apiDealersGet()
 
 Retrieves a list of all dealer entries.
 
@@ -62,10 +62,10 @@ Retrieves a list of all dealer entries.
 
 DealersApi apiInstance = new DealersApi();
 try {
-    List<DealerRecord> result = apiInstance.apiV2DealersGet();
+    List<DealerRecord> result = apiInstance.apiDealersGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling DealersApi#apiV2DealersGet");
+    System.err.println("Exception when calling DealersApi#apiDealersGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/EventConferenceDayRecord.md
+++ b/app/docs/EventConferenceDayRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **name** | **String** |  |  [optional]
 **date** | [**Date**](Date.md) |  |  [optional]
 

--- a/app/docs/EventConferenceDaysApi.md
+++ b/app/docs/EventConferenceDaysApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2EventConferenceDaysByIdGet**](EventConferenceDaysApi.md#apiV2EventConferenceDaysByIdGet) | **GET** /Api/v2/EventConferenceDays/{Id} | Retrieve a single event conference day in the event schedule.
-[**apiV2EventConferenceDaysGet**](EventConferenceDaysApi.md#apiV2EventConferenceDaysGet) | **GET** /Api/v2/EventConferenceDays | Retrieves a list of all event conference days in the event schedule.
+[**apiEventConferenceDaysByIdGet**](EventConferenceDaysApi.md#apiEventConferenceDaysByIdGet) | **GET** /Api/EventConferenceDays/{Id} | Retrieve a single event conference day in the event schedule.
+[**apiEventConferenceDaysGet**](EventConferenceDaysApi.md#apiEventConferenceDaysGet) | **GET** /Api/EventConferenceDays | Retrieves a list of all event conference days in the event schedule.
 
 
-<a name="apiV2EventConferenceDaysByIdGet"></a>
-# **apiV2EventConferenceDaysByIdGet**
-> EventConferenceDayRecord apiV2EventConferenceDaysByIdGet(id)
+<a name="apiEventConferenceDaysByIdGet"></a>
+# **apiEventConferenceDaysByIdGet**
+> EventConferenceDayRecord apiEventConferenceDaysByIdGet(id)
 
 Retrieve a single event conference day in the event schedule.
 
@@ -22,10 +22,10 @@ Retrieve a single event conference day in the event schedule.
 EventConferenceDaysApi apiInstance = new EventConferenceDaysApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    EventConferenceDayRecord result = apiInstance.apiV2EventConferenceDaysByIdGet(id);
+    EventConferenceDayRecord result = apiInstance.apiEventConferenceDaysByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceDaysApi#apiV2EventConferenceDaysByIdGet");
+    System.err.println("Exception when calling EventConferenceDaysApi#apiEventConferenceDaysByIdGet");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2EventConferenceDaysGet"></a>
-# **apiV2EventConferenceDaysGet**
-> List&lt;EventConferenceDayRecord&gt; apiV2EventConferenceDaysGet()
+<a name="apiEventConferenceDaysGet"></a>
+# **apiEventConferenceDaysGet**
+> List&lt;EventConferenceDayRecord&gt; apiEventConferenceDaysGet()
 
 Retrieves a list of all event conference days in the event schedule.
 
@@ -62,10 +62,10 @@ Retrieves a list of all event conference days in the event schedule.
 
 EventConferenceDaysApi apiInstance = new EventConferenceDaysApi();
 try {
-    List<EventConferenceDayRecord> result = apiInstance.apiV2EventConferenceDaysGet();
+    List<EventConferenceDayRecord> result = apiInstance.apiEventConferenceDaysGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceDaysApi#apiV2EventConferenceDaysGet");
+    System.err.println("Exception when calling EventConferenceDaysApi#apiEventConferenceDaysGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/EventConferenceRoomRecord.md
+++ b/app/docs/EventConferenceRoomRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **name** | **String** |  |  [optional]
 
 

--- a/app/docs/EventConferenceRoomsApi.md
+++ b/app/docs/EventConferenceRoomsApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2EventConferenceRoomsByIdGet**](EventConferenceRoomsApi.md#apiV2EventConferenceRoomsByIdGet) | **GET** /Api/v2/EventConferenceRooms/{Id} | Retrieve a single event conference room in the event schedule.
-[**apiV2EventConferenceRoomsGet**](EventConferenceRoomsApi.md#apiV2EventConferenceRoomsGet) | **GET** /Api/v2/EventConferenceRooms | Retrieves a list of all event conference Rooms in the event schedule.
+[**apiEventConferenceRoomsByIdGet**](EventConferenceRoomsApi.md#apiEventConferenceRoomsByIdGet) | **GET** /Api/EventConferenceRooms/{Id} | Retrieve a single event conference room in the event schedule.
+[**apiEventConferenceRoomsGet**](EventConferenceRoomsApi.md#apiEventConferenceRoomsGet) | **GET** /Api/EventConferenceRooms | Retrieves a list of all event conference Rooms in the event schedule.
 
 
-<a name="apiV2EventConferenceRoomsByIdGet"></a>
-# **apiV2EventConferenceRoomsByIdGet**
-> EventConferenceRoomRecord apiV2EventConferenceRoomsByIdGet(id)
+<a name="apiEventConferenceRoomsByIdGet"></a>
+# **apiEventConferenceRoomsByIdGet**
+> EventConferenceRoomRecord apiEventConferenceRoomsByIdGet(id)
 
 Retrieve a single event conference room in the event schedule.
 
@@ -22,10 +22,10 @@ Retrieve a single event conference room in the event schedule.
 EventConferenceRoomsApi apiInstance = new EventConferenceRoomsApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    EventConferenceRoomRecord result = apiInstance.apiV2EventConferenceRoomsByIdGet(id);
+    EventConferenceRoomRecord result = apiInstance.apiEventConferenceRoomsByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceRoomsApi#apiV2EventConferenceRoomsByIdGet");
+    System.err.println("Exception when calling EventConferenceRoomsApi#apiEventConferenceRoomsByIdGet");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2EventConferenceRoomsGet"></a>
-# **apiV2EventConferenceRoomsGet**
-> List&lt;EventConferenceRoomRecord&gt; apiV2EventConferenceRoomsGet()
+<a name="apiEventConferenceRoomsGet"></a>
+# **apiEventConferenceRoomsGet**
+> List&lt;EventConferenceRoomRecord&gt; apiEventConferenceRoomsGet()
 
 Retrieves a list of all event conference Rooms in the event schedule.
 
@@ -62,10 +62,10 @@ Retrieves a list of all event conference Rooms in the event schedule.
 
 EventConferenceRoomsApi apiInstance = new EventConferenceRoomsApi();
 try {
-    List<EventConferenceRoomRecord> result = apiInstance.apiV2EventConferenceRoomsGet();
+    List<EventConferenceRoomRecord> result = apiInstance.apiEventConferenceRoomsGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceRoomsApi#apiV2EventConferenceRoomsGet");
+    System.err.println("Exception when calling EventConferenceRoomsApi#apiEventConferenceRoomsGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/EventConferenceTrackRecord.md
+++ b/app/docs/EventConferenceTrackRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **name** | **String** |  |  [optional]
 
 

--- a/app/docs/EventConferenceTracksApi.md
+++ b/app/docs/EventConferenceTracksApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2EventConferenceTracksByIdGet**](EventConferenceTracksApi.md#apiV2EventConferenceTracksByIdGet) | **GET** /Api/v2/EventConferenceTracks/{Id} | Retrieve a single event conference track in the event schedule.
-[**apiV2EventConferenceTracksGet**](EventConferenceTracksApi.md#apiV2EventConferenceTracksGet) | **GET** /Api/v2/EventConferenceTracks | Retrieves a list of all event conference tracks in the event schedule.
+[**apiEventConferenceTracksByIdGet**](EventConferenceTracksApi.md#apiEventConferenceTracksByIdGet) | **GET** /Api/EventConferenceTracks/{Id} | Retrieve a single event conference track in the event schedule.
+[**apiEventConferenceTracksGet**](EventConferenceTracksApi.md#apiEventConferenceTracksGet) | **GET** /Api/EventConferenceTracks | Retrieves a list of all event conference tracks in the event schedule.
 
 
-<a name="apiV2EventConferenceTracksByIdGet"></a>
-# **apiV2EventConferenceTracksByIdGet**
-> EventConferenceTrackRecord apiV2EventConferenceTracksByIdGet(id)
+<a name="apiEventConferenceTracksByIdGet"></a>
+# **apiEventConferenceTracksByIdGet**
+> EventConferenceTrackRecord apiEventConferenceTracksByIdGet(id)
 
 Retrieve a single event conference track in the event schedule.
 
@@ -22,10 +22,10 @@ Retrieve a single event conference track in the event schedule.
 EventConferenceTracksApi apiInstance = new EventConferenceTracksApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    EventConferenceTrackRecord result = apiInstance.apiV2EventConferenceTracksByIdGet(id);
+    EventConferenceTrackRecord result = apiInstance.apiEventConferenceTracksByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceTracksApi#apiV2EventConferenceTracksByIdGet");
+    System.err.println("Exception when calling EventConferenceTracksApi#apiEventConferenceTracksByIdGet");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2EventConferenceTracksGet"></a>
-# **apiV2EventConferenceTracksGet**
-> List&lt;EventConferenceTrackRecord&gt; apiV2EventConferenceTracksGet()
+<a name="apiEventConferenceTracksGet"></a>
+# **apiEventConferenceTracksGet**
+> List&lt;EventConferenceTrackRecord&gt; apiEventConferenceTracksGet()
 
 Retrieves a list of all event conference tracks in the event schedule.
 
@@ -62,10 +62,10 @@ Retrieves a list of all event conference tracks in the event schedule.
 
 EventConferenceTracksApi apiInstance = new EventConferenceTracksApi();
 try {
-    List<EventConferenceTrackRecord> result = apiInstance.apiV2EventConferenceTracksGet();
+    List<EventConferenceTrackRecord> result = apiInstance.apiEventConferenceTracksGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventConferenceTracksApi#apiV2EventConferenceTracksGet");
+    System.err.println("Exception when calling EventConferenceTracksApi#apiEventConferenceTracksGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/EventFeedbackApi.md
+++ b/app/docs/EventFeedbackApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2EventFeedbackGet**](EventFeedbackApi.md#apiV2EventFeedbackGet) | **GET** /Api/v2/EventFeedback | 
-[**apiV2EventFeedbackPost**](EventFeedbackApi.md#apiV2EventFeedbackPost) | **POST** /Api/v2/EventFeedback | 
+[**apiEventFeedbackGet**](EventFeedbackApi.md#apiEventFeedbackGet) | **GET** /Api/EventFeedback | 
+[**apiEventFeedbackPost**](EventFeedbackApi.md#apiEventFeedbackPost) | **POST** /Api/EventFeedback | 
 
 
-<a name="apiV2EventFeedbackGet"></a>
-# **apiV2EventFeedbackGet**
-> List&lt;EventFeedbackRecord&gt; apiV2EventFeedbackGet()
+<a name="apiEventFeedbackGet"></a>
+# **apiEventFeedbackGet**
+> List&lt;EventFeedbackRecord&gt; apiEventFeedbackGet()
 
 
 
@@ -23,10 +23,10 @@ Method | HTTP request | Description
 
 EventFeedbackApi apiInstance = new EventFeedbackApi();
 try {
-    List<EventFeedbackRecord> result = apiInstance.apiV2EventFeedbackGet();
+    List<EventFeedbackRecord> result = apiInstance.apiEventFeedbackGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventFeedbackApi#apiV2EventFeedbackGet");
+    System.err.println("Exception when calling EventFeedbackApi#apiEventFeedbackGet");
     e.printStackTrace();
 }
 ```
@@ -47,9 +47,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2EventFeedbackPost"></a>
-# **apiV2EventFeedbackPost**
-> apiV2EventFeedbackPost(record)
+<a name="apiEventFeedbackPost"></a>
+# **apiEventFeedbackPost**
+> apiEventFeedbackPost(record)
 
 
 
@@ -63,9 +63,9 @@ This endpoint does not need any parameter.
 EventFeedbackApi apiInstance = new EventFeedbackApi();
 EventFeedbackRecord record = new EventFeedbackRecord(); // EventFeedbackRecord | 
 try {
-    apiInstance.apiV2EventFeedbackPost(record);
+    apiInstance.apiEventFeedbackPost(record);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventFeedbackApi#apiV2EventFeedbackPost");
+    System.err.println("Exception when calling EventFeedbackApi#apiEventFeedbackPost");
     e.printStackTrace();
 }
 ```

--- a/app/docs/EventFeedbackRecord.md
+++ b/app/docs/EventFeedbackRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **eventId** | [**UUID**](UUID.md) |  |  [optional]
 **authorUid** | **String** |  |  [optional]
 **rating** | **Integer** |  |  [optional]

--- a/app/docs/EventRecord.md
+++ b/app/docs/EventRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **slug** | **String** |  |  [optional]
 **title** | **String** |  |  [optional]
 **subTitle** | **String** |  |  [optional]

--- a/app/docs/EventsApi.md
+++ b/app/docs/EventsApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2EventsByIdGet**](EventsApi.md#apiV2EventsByIdGet) | **GET** /Api/v2/Events/{Id} | Retrieve a single event in the event schedule.
-[**apiV2EventsGet**](EventsApi.md#apiV2EventsGet) | **GET** /Api/v2/Events | Retrieves a list of all events in the event schedule.
+[**apiEventsByIdGet**](EventsApi.md#apiEventsByIdGet) | **GET** /Api/Events/{Id} | Retrieve a single event in the event schedule.
+[**apiEventsGet**](EventsApi.md#apiEventsGet) | **GET** /Api/Events | Retrieves a list of all events in the event schedule.
 
 
-<a name="apiV2EventsByIdGet"></a>
-# **apiV2EventsByIdGet**
-> EventRecord apiV2EventsByIdGet(id)
+<a name="apiEventsByIdGet"></a>
+# **apiEventsByIdGet**
+> EventRecord apiEventsByIdGet(id)
 
 Retrieve a single event in the event schedule.
 
@@ -22,10 +22,10 @@ Retrieve a single event in the event schedule.
 EventsApi apiInstance = new EventsApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    EventRecord result = apiInstance.apiV2EventsByIdGet(id);
+    EventRecord result = apiInstance.apiEventsByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventsApi#apiV2EventsByIdGet");
+    System.err.println("Exception when calling EventsApi#apiEventsByIdGet");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2EventsGet"></a>
-# **apiV2EventsGet**
-> List&lt;EventRecord&gt; apiV2EventsGet()
+<a name="apiEventsGet"></a>
+# **apiEventsGet**
+> List&lt;EventRecord&gt; apiEventsGet()
 
 Retrieves a list of all events in the event schedule.
 
@@ -62,10 +62,10 @@ Retrieves a list of all events in the event schedule.
 
 EventsApi apiInstance = new EventsApi();
 try {
-    List<EventRecord> result = apiInstance.apiV2EventsGet();
+    List<EventRecord> result = apiInstance.apiEventsGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling EventsApi#apiV2EventsGet");
+    System.err.println("Exception when calling EventsApi#apiEventsGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/FursuitBadgeRecord.md
+++ b/app/docs/FursuitBadgeRecord.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **externalReference** | **String** |  |  [optional]
 **ownerUid** | **String** |  | 
 **name** | **String** |  | 

--- a/app/docs/FursuitParticipationRecord.md
+++ b/app/docs/FursuitParticipationRecord.md
@@ -4,13 +4,14 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **ownerUid** | **String** |  |  [optional]
 **fursuitBadgeId** | [**UUID**](UUID.md) |  |  [optional]
 **tokenValue** | **String** |  |  [optional]
 **isBanned** | **Boolean** |  |  [optional]
 **tokenRegistrationDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
+**lastCollectionDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
 **collectionCount** | **Integer** |  |  [optional]
 
 

--- a/app/docs/FursuitsApi.md
+++ b/app/docs/FursuitsApi.md
@@ -4,25 +4,26 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2FursuitsBadgesByIdImageGet**](FursuitsApi.md#apiV2FursuitsBadgesByIdImageGet) | **GET** /Api/v2/Fursuits/Badges/{Id}/Image | Retrieve the badge image content for a given fursuit badge id
-[**apiV2FursuitsBadgesGet**](FursuitsApi.md#apiV2FursuitsBadgesGet) | **GET** /Api/v2/Fursuits/Badges | Return all Fursuit Badge Registrations
-[**apiV2FursuitsBadgesRegistrationPost**](FursuitsApi.md#apiV2FursuitsBadgesRegistrationPost) | **POST** /Api/v2/Fursuits/Badges/Registration | Upsert Fursuit Badge information
-[**apiV2FursuitsCollectingGameFursuitParticipationGet**](FursuitsApi.md#apiV2FursuitsCollectingGameFursuitParticipationGet) | **GET** /Api/v2/Fursuits/CollectingGame/FursuitParticipation | 
-[**apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet**](FursuitsApi.md#apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet) | **GET** /Api/v2/Fursuits/CollectingGame/FursuitParticipation/Scoreboard | 
-[**apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost**](FursuitsApi.md#apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost) | **POST** /Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token | Register (link/assign) a valid, unused token to a fursuit badge.
-[**apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost**](FursuitsApi.md#apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost) | **POST** /Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe | 
-[**apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost**](FursuitsApi.md#apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost) | **POST** /Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken | 
-[**apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost**](FursuitsApi.md#apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost) | **POST** /Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe | 
-[**apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet**](FursuitsApi.md#apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet) | **GET** /Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries | 
-[**apiV2FursuitsCollectingGamePlayerParticipationGet**](FursuitsApi.md#apiV2FursuitsCollectingGamePlayerParticipationGet) | **GET** /Api/v2/Fursuits/CollectingGame/PlayerParticipation | 
-[**apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet**](FursuitsApi.md#apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet) | **GET** /Api/v2/Fursuits/CollectingGame/PlayerParticipation/Scoreboard | 
-[**apiV2FursuitsCollectingGameTokensBatchPost**](FursuitsApi.md#apiV2FursuitsCollectingGameTokensBatchPost) | **POST** /Api/v2/Fursuits/CollectingGame/Tokens/Batch | 
-[**apiV2FursuitsCollectingGameTokensPost**](FursuitsApi.md#apiV2FursuitsCollectingGameTokensPost) | **POST** /Api/v2/Fursuits/CollectingGame/Tokens | 
+[**apiFursuitsBadgesByIdImageGet**](FursuitsApi.md#apiFursuitsBadgesByIdImageGet) | **GET** /Api/Fursuits/Badges/{Id}/Image | Retrieve the badge image content for a given fursuit badge id
+[**apiFursuitsBadgesGet**](FursuitsApi.md#apiFursuitsBadgesGet) | **GET** /Api/Fursuits/Badges | Return all Fursuit Badge Registrations
+[**apiFursuitsBadgesRegistrationPost**](FursuitsApi.md#apiFursuitsBadgesRegistrationPost) | **POST** /Api/Fursuits/Badges/Registration | Upsert Fursuit Badge information
+[**apiFursuitsCollectingGameFursuitParticipationGet**](FursuitsApi.md#apiFursuitsCollectingGameFursuitParticipationGet) | **GET** /Api/Fursuits/CollectingGame/FursuitParticipation | 
+[**apiFursuitsCollectingGameFursuitParticipationScoreboardGet**](FursuitsApi.md#apiFursuitsCollectingGameFursuitParticipationScoreboardGet) | **GET** /Api/Fursuits/CollectingGame/FursuitParticipation/Scoreboard | 
+[**apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost**](FursuitsApi.md#apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost) | **POST** /Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token | Register (link/assign) a valid, unused token to a fursuit badge.
+[**apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost**](FursuitsApi.md#apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost) | **POST** /Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe | 
+[**apiFursuitsCollectingGamePlayerParticipationCollectTokenPost**](FursuitsApi.md#apiFursuitsCollectingGamePlayerParticipationCollectTokenPost) | **POST** /Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken | 
+[**apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost**](FursuitsApi.md#apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost) | **POST** /Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe | 
+[**apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet**](FursuitsApi.md#apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet) | **GET** /Api/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries | 
+[**apiFursuitsCollectingGamePlayerParticipationGet**](FursuitsApi.md#apiFursuitsCollectingGamePlayerParticipationGet) | **GET** /Api/Fursuits/CollectingGame/PlayerParticipation | 
+[**apiFursuitsCollectingGamePlayerParticipationScoreboardGet**](FursuitsApi.md#apiFursuitsCollectingGamePlayerParticipationScoreboardGet) | **GET** /Api/Fursuits/CollectingGame/PlayerParticipation/Scoreboard | 
+[**apiFursuitsCollectingGameRecalculatePost**](FursuitsApi.md#apiFursuitsCollectingGameRecalculatePost) | **POST** /Api/Fursuits/CollectingGame/Recalculate | 
+[**apiFursuitsCollectingGameTokensBatchPost**](FursuitsApi.md#apiFursuitsCollectingGameTokensBatchPost) | **POST** /Api/Fursuits/CollectingGame/Tokens/Batch | 
+[**apiFursuitsCollectingGameTokensPost**](FursuitsApi.md#apiFursuitsCollectingGameTokensPost) | **POST** /Api/Fursuits/CollectingGame/Tokens | 
 
 
-<a name="apiV2FursuitsBadgesByIdImageGet"></a>
-# **apiV2FursuitsBadgesByIdImageGet**
-> byte[] apiV2FursuitsBadgesByIdImageGet(id)
+<a name="apiFursuitsBadgesByIdImageGet"></a>
+# **apiFursuitsBadgesByIdImageGet**
+> byte[] apiFursuitsBadgesByIdImageGet(id)
 
 Retrieve the badge image content for a given fursuit badge id
 
@@ -34,10 +35,10 @@ Retrieve the badge image content for a given fursuit badge id
 FursuitsApi apiInstance = new FursuitsApi();
 UUID id = new UUID(); // UUID | \"Id\" of the fursuit badge
 try {
-    byte[] result = apiInstance.apiV2FursuitsBadgesByIdImageGet(id);
+    byte[] result = apiInstance.apiFursuitsBadgesByIdImageGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsBadgesByIdImageGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsBadgesByIdImageGet");
     e.printStackTrace();
 }
 ```
@@ -61,9 +62,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsBadgesGet"></a>
-# **apiV2FursuitsBadgesGet**
-> List&lt;FursuitBadgeRecord&gt; apiV2FursuitsBadgesGet()
+<a name="apiFursuitsBadgesGet"></a>
+# **apiFursuitsBadgesGet**
+> List&lt;FursuitBadgeRecord&gt; apiFursuitsBadgesGet()
 
 Return all Fursuit Badge Registrations
 
@@ -76,10 +77,10 @@ Return all Fursuit Badge Registrations
 
 FursuitsApi apiInstance = new FursuitsApi();
 try {
-    List<FursuitBadgeRecord> result = apiInstance.apiV2FursuitsBadgesGet();
+    List<FursuitBadgeRecord> result = apiInstance.apiFursuitsBadgesGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsBadgesGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsBadgesGet");
     e.printStackTrace();
 }
 ```
@@ -100,9 +101,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsBadgesRegistrationPost"></a>
-# **apiV2FursuitsBadgesRegistrationPost**
-> apiV2FursuitsBadgesRegistrationPost(registration)
+<a name="apiFursuitsBadgesRegistrationPost"></a>
+# **apiFursuitsBadgesRegistrationPost**
+> apiFursuitsBadgesRegistrationPost(registration)
 
 Upsert Fursuit Badge information
 
@@ -116,9 +117,9 @@ Upsert Fursuit Badge information
 FursuitsApi apiInstance = new FursuitsApi();
 FursuitBadgeRegistration registration = new FursuitBadgeRegistration(); // FursuitBadgeRegistration | 
 try {
-    apiInstance.apiV2FursuitsBadgesRegistrationPost(registration);
+    apiInstance.apiFursuitsBadgesRegistrationPost(registration);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsBadgesRegistrationPost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsBadgesRegistrationPost");
     e.printStackTrace();
 }
 ```
@@ -142,9 +143,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameFursuitParticipationGet"></a>
-# **apiV2FursuitsCollectingGameFursuitParticipationGet**
-> List&lt;FursuitParticipationInfo&gt; apiV2FursuitsCollectingGameFursuitParticipationGet()
+<a name="apiFursuitsCollectingGameFursuitParticipationGet"></a>
+# **apiFursuitsCollectingGameFursuitParticipationGet**
+> List&lt;FursuitParticipationInfo&gt; apiFursuitsCollectingGameFursuitParticipationGet()
 
 
 
@@ -157,10 +158,10 @@ null (empty response body)
 
 FursuitsApi apiInstance = new FursuitsApi();
 try {
-    List<FursuitParticipationInfo> result = apiInstance.apiV2FursuitsCollectingGameFursuitParticipationGet();
+    List<FursuitParticipationInfo> result = apiInstance.apiFursuitsCollectingGameFursuitParticipationGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameFursuitParticipationGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameFursuitParticipationGet");
     e.printStackTrace();
 }
 ```
@@ -181,9 +182,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet"></a>
-# **apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet**
-> List&lt;FursuitScoreboardEntry&gt; apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet(top)
+<a name="apiFursuitsCollectingGameFursuitParticipationScoreboardGet"></a>
+# **apiFursuitsCollectingGameFursuitParticipationScoreboardGet**
+> List&lt;FursuitScoreboardEntry&gt; apiFursuitsCollectingGameFursuitParticipationScoreboardGet(top)
 
 
 
@@ -193,12 +194,12 @@ This endpoint does not need any parameter.
 //import io.swagger.client.api.FursuitsApi;
 
 FursuitsApi apiInstance = new FursuitsApi();
-Integer top = 56; // Integer | 
+Integer top = 25; // Integer | 
 try {
-    List<FursuitScoreboardEntry> result = apiInstance.apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet(top);
+    List<FursuitScoreboardEntry> result = apiInstance.apiFursuitsCollectingGameFursuitParticipationScoreboardGet(top);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameFursuitParticipationScoreboardGet");
     e.printStackTrace();
 }
 ```
@@ -207,7 +208,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **top** | **Integer**|  | [optional]
+ **top** | **Integer**|  | [optional] [default to 25]
 
 ### Return type
 
@@ -222,9 +223,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"></a>
-# **apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost**
-> apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost(fursuitBadgeId, tokenValue)
+<a name="apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"></a>
+# **apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost**
+> apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost(fursuitBadgeId, tokenValue)
 
 Register (link/assign) a valid, unused token to a fursuit badge.
 
@@ -239,9 +240,9 @@ FursuitsApi apiInstance = new FursuitsApi();
 UUID fursuitBadgeId = new UUID(); // UUID | 
 String tokenValue = "tokenValue_example"; // String | 
 try {
-    apiInstance.apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost(fursuitBadgeId, tokenValue);
+    apiInstance.apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost(fursuitBadgeId, tokenValue);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost");
     e.printStackTrace();
 }
 ```
@@ -266,9 +267,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"></a>
-# **apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost**
-> ApiSafeResult apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost(fursuitBadgeId, tokenValue)
+<a name="apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"></a>
+# **apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost**
+> ApiSafeResult apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost(fursuitBadgeId, tokenValue)
 
 
 
@@ -283,10 +284,10 @@ FursuitsApi apiInstance = new FursuitsApi();
 UUID fursuitBadgeId = new UUID(); // UUID | 
 String tokenValue = "tokenValue_example"; // String | 
 try {
-    ApiSafeResult result = apiInstance.apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost(fursuitBadgeId, tokenValue);
+    ApiSafeResult result = apiInstance.apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost(fursuitBadgeId, tokenValue);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost");
     e.printStackTrace();
 }
 ```
@@ -311,9 +312,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost"></a>
-# **apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost**
-> CollectTokenResponse apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost(tokenValue)
+<a name="apiFursuitsCollectingGamePlayerParticipationCollectTokenPost"></a>
+# **apiFursuitsCollectingGamePlayerParticipationCollectTokenPost**
+> CollectTokenResponse apiFursuitsCollectingGamePlayerParticipationCollectTokenPost(tokenValue)
 
 
 
@@ -327,10 +328,10 @@ Name | Type | Description  | Notes
 FursuitsApi apiInstance = new FursuitsApi();
 String tokenValue = "tokenValue_example"; // String | 
 try {
-    CollectTokenResponse result = apiInstance.apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost(tokenValue);
+    CollectTokenResponse result = apiInstance.apiFursuitsCollectingGamePlayerParticipationCollectTokenPost(tokenValue);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGamePlayerParticipationCollectTokenPost");
     e.printStackTrace();
 }
 ```
@@ -354,9 +355,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost"></a>
-# **apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost**
-> ApiSafeResultCollectTokenResponse apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tokenValue)
+<a name="apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost"></a>
+# **apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost**
+> ApiSafeResultCollectTokenResponse apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tokenValue)
 
 
 
@@ -370,10 +371,10 @@ Name | Type | Description  | Notes
 FursuitsApi apiInstance = new FursuitsApi();
 String tokenValue = "tokenValue_example"; // String | 
 try {
-    ApiSafeResultCollectTokenResponse result = apiInstance.apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tokenValue);
+    ApiSafeResultCollectTokenResponse result = apiInstance.apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tokenValue);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost");
     e.printStackTrace();
 }
 ```
@@ -397,9 +398,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet"></a>
-# **apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet**
-> List&lt;PlayerCollectionEntry&gt; apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet()
+<a name="apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet"></a>
+# **apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet**
+> List&lt;PlayerCollectionEntry&gt; apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet()
 
 
 
@@ -412,10 +413,10 @@ Name | Type | Description  | Notes
 
 FursuitsApi apiInstance = new FursuitsApi();
 try {
-    List<PlayerCollectionEntry> result = apiInstance.apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet();
+    List<PlayerCollectionEntry> result = apiInstance.apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet");
     e.printStackTrace();
 }
 ```
@@ -436,9 +437,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGamePlayerParticipationGet"></a>
-# **apiV2FursuitsCollectingGamePlayerParticipationGet**
-> PlayerParticipationInfo apiV2FursuitsCollectingGamePlayerParticipationGet()
+<a name="apiFursuitsCollectingGamePlayerParticipationGet"></a>
+# **apiFursuitsCollectingGamePlayerParticipationGet**
+> PlayerParticipationInfo apiFursuitsCollectingGamePlayerParticipationGet()
 
 
 
@@ -451,10 +452,10 @@ This endpoint does not need any parameter.
 
 FursuitsApi apiInstance = new FursuitsApi();
 try {
-    PlayerParticipationInfo result = apiInstance.apiV2FursuitsCollectingGamePlayerParticipationGet();
+    PlayerParticipationInfo result = apiInstance.apiFursuitsCollectingGamePlayerParticipationGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGamePlayerParticipationGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGamePlayerParticipationGet");
     e.printStackTrace();
 }
 ```
@@ -475,9 +476,9 @@ This endpoint does not need any parameter.
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet"></a>
-# **apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet**
-> List&lt;PlayerScoreboardEntry&gt; apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet(top)
+<a name="apiFursuitsCollectingGamePlayerParticipationScoreboardGet"></a>
+# **apiFursuitsCollectingGamePlayerParticipationScoreboardGet**
+> List&lt;PlayerScoreboardEntry&gt; apiFursuitsCollectingGamePlayerParticipationScoreboardGet(top)
 
 
 
@@ -487,12 +488,12 @@ This endpoint does not need any parameter.
 //import io.swagger.client.api.FursuitsApi;
 
 FursuitsApi apiInstance = new FursuitsApi();
-Integer top = 56; // Integer | 
+Integer top = 25; // Integer | 
 try {
-    List<PlayerScoreboardEntry> result = apiInstance.apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet(top);
+    List<PlayerScoreboardEntry> result = apiInstance.apiFursuitsCollectingGamePlayerParticipationScoreboardGet(top);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGamePlayerParticipationScoreboardGet");
     e.printStackTrace();
 }
 ```
@@ -501,7 +502,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **top** | **Integer**|  | [optional]
+ **top** | **Integer**|  | [optional] [default to 25]
 
 ### Return type
 
@@ -516,9 +517,47 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameTokensBatchPost"></a>
-# **apiV2FursuitsCollectingGameTokensBatchPost**
-> apiV2FursuitsCollectingGameTokensBatchPost(tokenValues)
+<a name="apiFursuitsCollectingGameRecalculatePost"></a>
+# **apiFursuitsCollectingGameRecalculatePost**
+> apiFursuitsCollectingGameRecalculatePost()
+
+
+
+  * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.api.FursuitsApi;
+
+FursuitsApi apiInstance = new FursuitsApi();
+try {
+    apiInstance.apiFursuitsCollectingGameRecalculatePost();
+} catch (ApiException e) {
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameRecalculatePost");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain, application/json, text/json
+
+<a name="apiFursuitsCollectingGameTokensBatchPost"></a>
+# **apiFursuitsCollectingGameTokensBatchPost**
+> apiFursuitsCollectingGameTokensBatchPost(tokenValues)
 
 
 
@@ -532,9 +571,9 @@ No authorization required
 FursuitsApi apiInstance = new FursuitsApi();
 List<String> tokenValues = Arrays.asList(new List<String>()); // List<String> | 
 try {
-    apiInstance.apiV2FursuitsCollectingGameTokensBatchPost(tokenValues);
+    apiInstance.apiFursuitsCollectingGameTokensBatchPost(tokenValues);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameTokensBatchPost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameTokensBatchPost");
     e.printStackTrace();
 }
 ```
@@ -558,9 +597,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2FursuitsCollectingGameTokensPost"></a>
-# **apiV2FursuitsCollectingGameTokensPost**
-> apiV2FursuitsCollectingGameTokensPost(tokenValue)
+<a name="apiFursuitsCollectingGameTokensPost"></a>
+# **apiFursuitsCollectingGameTokensPost**
+> apiFursuitsCollectingGameTokensPost(tokenValue)
 
 
 
@@ -574,9 +613,9 @@ null (empty response body)
 FursuitsApi apiInstance = new FursuitsApi();
 String tokenValue = "tokenValue_example"; // String | 
 try {
-    apiInstance.apiV2FursuitsCollectingGameTokensPost(tokenValue);
+    apiInstance.apiFursuitsCollectingGameTokensPost(tokenValue);
 } catch (ApiException e) {
-    System.err.println("Exception when calling FursuitsApi#apiV2FursuitsCollectingGameTokensPost");
+    System.err.println("Exception when calling FursuitsApi#apiFursuitsCollectingGameTokensPost");
     e.printStackTrace();
 }
 ```

--- a/app/docs/ImageRecord.md
+++ b/app/docs/ImageRecord.md
@@ -4,12 +4,12 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **internalReference** | **String** |  | 
-**width** | **Integer** |  |  [optional]
-**height** | **Integer** |  |  [optional]
-**sizeInBytes** | **Long** |  |  [optional]
+**width** | **Integer** |  | 
+**height** | **Integer** |  | 
+**sizeInBytes** | **Long** |  | 
 **mimeType** | **String** |  | 
 **contentHashSha1** | **String** |  | 
 

--- a/app/docs/ImagesApi.md
+++ b/app/docs/ImagesApi.md
@@ -4,15 +4,16 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2ImagesByIdContentGet**](ImagesApi.md#apiV2ImagesByIdContentGet) | **GET** /Api/v2/Images/{Id}/Content | Retrieve a single image content.
-[**apiV2ImagesByIdContentPut**](ImagesApi.md#apiV2ImagesByIdContentPut) | **PUT** /Api/v2/Images/{Id}/Content | 
-[**apiV2ImagesByIdGet**](ImagesApi.md#apiV2ImagesByIdGet) | **GET** /Api/v2/Images/{Id} | Retrieve a single image.
-[**apiV2ImagesGet**](ImagesApi.md#apiV2ImagesGet) | **GET** /Api/v2/Images | Retrieves a list of all images.
+[**apiImagesByIdContentGet**](ImagesApi.md#apiImagesByIdContentGet) | **GET** /Api/Images/{Id}/Content | Retrieve a single image content.
+[**apiImagesByIdContentPut**](ImagesApi.md#apiImagesByIdContentPut) | **PUT** /Api/Images/{Id}/Content | 
+[**apiImagesByIdContentWithHashcontentHashBase64EncodedGet**](ImagesApi.md#apiImagesByIdContentWithHashcontentHashBase64EncodedGet) | **GET** /Api/Images/{Id}/Content/with-hash:{contentHashBase64Encoded} | Retrieve a single image content using hash code (preferred, as it allows caching).
+[**apiImagesByIdGet**](ImagesApi.md#apiImagesByIdGet) | **GET** /Api/Images/{Id} | Retrieve a single image.
+[**apiImagesGet**](ImagesApi.md#apiImagesGet) | **GET** /Api/Images | Retrieves a list of all images.
 
 
-<a name="apiV2ImagesByIdContentGet"></a>
-# **apiV2ImagesByIdContentGet**
-> byte[] apiV2ImagesByIdContentGet(id)
+<a name="apiImagesByIdContentGet"></a>
+# **apiImagesByIdContentGet**
+> byte[] apiImagesByIdContentGet(id)
 
 Retrieve a single image content.
 
@@ -24,10 +25,10 @@ Retrieve a single image content.
 ImagesApi apiInstance = new ImagesApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    byte[] result = apiInstance.apiV2ImagesByIdContentGet(id);
+    byte[] result = apiInstance.apiImagesByIdContentGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling ImagesApi#apiV2ImagesByIdContentGet");
+    System.err.println("Exception when calling ImagesApi#apiImagesByIdContentGet");
     e.printStackTrace();
 }
 ```
@@ -51,9 +52,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2ImagesByIdContentPut"></a>
-# **apiV2ImagesByIdContentPut**
-> apiV2ImagesByIdContentPut(id, imageContent)
+<a name="apiImagesByIdContentPut"></a>
+# **apiImagesByIdContentPut**
+> apiImagesByIdContentPut(id, imageContent)
 
 
 
@@ -68,9 +69,9 @@ ImagesApi apiInstance = new ImagesApi();
 UUID id = new UUID(); // UUID | 
 String imageContent = "imageContent_example"; // String | 
 try {
-    apiInstance.apiV2ImagesByIdContentPut(id, imageContent);
+    apiInstance.apiImagesByIdContentPut(id, imageContent);
 } catch (ApiException e) {
-    System.err.println("Exception when calling ImagesApi#apiV2ImagesByIdContentPut");
+    System.err.println("Exception when calling ImagesApi#apiImagesByIdContentPut");
     e.printStackTrace();
 }
 ```
@@ -95,9 +96,52 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: Not defined
 
-<a name="apiV2ImagesByIdGet"></a>
-# **apiV2ImagesByIdGet**
-> ImageRecord apiV2ImagesByIdGet(id)
+<a name="apiImagesByIdContentWithHashcontentHashBase64EncodedGet"></a>
+# **apiImagesByIdContentWithHashcontentHashBase64EncodedGet**
+> byte[] apiImagesByIdContentWithHashcontentHashBase64EncodedGet(id, contentHashBase64Encoded)
+
+Retrieve a single image content using hash code (preferred, as it allows caching).
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.api.ImagesApi;
+
+ImagesApi apiInstance = new ImagesApi();
+UUID id = new UUID(); // UUID | id of the requested entity
+String contentHashBase64Encoded = "contentHashBase64Encoded_example"; // String | Base64 Encoded ContentHashSha1 of the requested entity
+try {
+    byte[] result = apiInstance.apiImagesByIdContentWithHashcontentHashBase64EncodedGet(id, contentHashBase64Encoded);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling ImagesApi#apiImagesByIdContentWithHashcontentHashBase64EncodedGet");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | [**UUID**](.md)| id of the requested entity |
+ **contentHashBase64Encoded** | **String**| Base64 Encoded ContentHashSha1 of the requested entity |
+
+### Return type
+
+**byte[]**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain, application/json, text/json
+
+<a name="apiImagesByIdGet"></a>
+# **apiImagesByIdGet**
+> ImageRecord apiImagesByIdGet(id)
 
 Retrieve a single image.
 
@@ -109,10 +153,10 @@ Retrieve a single image.
 ImagesApi apiInstance = new ImagesApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    ImageRecord result = apiInstance.apiV2ImagesByIdGet(id);
+    ImageRecord result = apiInstance.apiImagesByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling ImagesApi#apiV2ImagesByIdGet");
+    System.err.println("Exception when calling ImagesApi#apiImagesByIdGet");
     e.printStackTrace();
 }
 ```
@@ -136,9 +180,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2ImagesGet"></a>
-# **apiV2ImagesGet**
-> List&lt;ImageRecord&gt; apiV2ImagesGet()
+<a name="apiImagesGet"></a>
+# **apiImagesGet**
+> List&lt;ImageRecord&gt; apiImagesGet()
 
 Retrieves a list of all images.
 
@@ -149,10 +193,10 @@ Retrieves a list of all images.
 
 ImagesApi apiInstance = new ImagesApi();
 try {
-    List<ImageRecord> result = apiInstance.apiV2ImagesGet();
+    List<ImageRecord> result = apiInstance.apiImagesGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling ImagesApi#apiV2ImagesGet");
+    System.err.println("Exception when calling ImagesApi#apiImagesGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/KnowledgeEntriesApi.md
+++ b/app/docs/KnowledgeEntriesApi.md
@@ -4,16 +4,16 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2KnowledgeEntriesByIdDelete**](KnowledgeEntriesApi.md#apiV2KnowledgeEntriesByIdDelete) | **DELETE** /Api/v2/KnowledgeEntries/{Id} | Delete a knowledge entry.
-[**apiV2KnowledgeEntriesByIdGet**](KnowledgeEntriesApi.md#apiV2KnowledgeEntriesByIdGet) | **GET** /Api/v2/KnowledgeEntries/{Id} | Retrieve a single knowledge entry.
-[**apiV2KnowledgeEntriesByIdPut**](KnowledgeEntriesApi.md#apiV2KnowledgeEntriesByIdPut) | **PUT** /Api/v2/KnowledgeEntries/{Id} | Update an existing knowledge entry.
-[**apiV2KnowledgeEntriesGet**](KnowledgeEntriesApi.md#apiV2KnowledgeEntriesGet) | **GET** /Api/v2/KnowledgeEntries | Retrieves a list of all knowledge entries.
-[**apiV2KnowledgeEntriesPost**](KnowledgeEntriesApi.md#apiV2KnowledgeEntriesPost) | **POST** /Api/v2/KnowledgeEntries | Create a new knowledge entry.
+[**apiKnowledgeEntriesByIdDelete**](KnowledgeEntriesApi.md#apiKnowledgeEntriesByIdDelete) | **DELETE** /Api/KnowledgeEntries/{Id} | Delete a knowledge entry.
+[**apiKnowledgeEntriesByIdGet**](KnowledgeEntriesApi.md#apiKnowledgeEntriesByIdGet) | **GET** /Api/KnowledgeEntries/{Id} | Retrieve a single knowledge entry.
+[**apiKnowledgeEntriesByIdPut**](KnowledgeEntriesApi.md#apiKnowledgeEntriesByIdPut) | **PUT** /Api/KnowledgeEntries/{Id} | Update an existing knowledge entry.
+[**apiKnowledgeEntriesGet**](KnowledgeEntriesApi.md#apiKnowledgeEntriesGet) | **GET** /Api/KnowledgeEntries | Retrieves a list of all knowledge entries.
+[**apiKnowledgeEntriesPost**](KnowledgeEntriesApi.md#apiKnowledgeEntriesPost) | **POST** /Api/KnowledgeEntries | Create a new knowledge entry.
 
 
-<a name="apiV2KnowledgeEntriesByIdDelete"></a>
-# **apiV2KnowledgeEntriesByIdDelete**
-> apiV2KnowledgeEntriesByIdDelete(id)
+<a name="apiKnowledgeEntriesByIdDelete"></a>
+# **apiKnowledgeEntriesByIdDelete**
+> apiKnowledgeEntriesByIdDelete(id)
 
 Delete a knowledge entry.
 
@@ -27,9 +27,9 @@ Delete a knowledge entry.
 KnowledgeEntriesApi apiInstance = new KnowledgeEntriesApi();
 UUID id = new UUID(); // UUID | 
 try {
-    apiInstance.apiV2KnowledgeEntriesByIdDelete(id);
+    apiInstance.apiKnowledgeEntriesByIdDelete(id);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeEntriesApi#apiV2KnowledgeEntriesByIdDelete");
+    System.err.println("Exception when calling KnowledgeEntriesApi#apiKnowledgeEntriesByIdDelete");
     e.printStackTrace();
 }
 ```
@@ -53,9 +53,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeEntriesByIdGet"></a>
-# **apiV2KnowledgeEntriesByIdGet**
-> KnowledgeEntryRecord apiV2KnowledgeEntriesByIdGet(id)
+<a name="apiKnowledgeEntriesByIdGet"></a>
+# **apiKnowledgeEntriesByIdGet**
+> KnowledgeEntryRecord apiKnowledgeEntriesByIdGet(id)
 
 Retrieve a single knowledge entry.
 
@@ -67,10 +67,10 @@ Retrieve a single knowledge entry.
 KnowledgeEntriesApi apiInstance = new KnowledgeEntriesApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    KnowledgeEntryRecord result = apiInstance.apiV2KnowledgeEntriesByIdGet(id);
+    KnowledgeEntryRecord result = apiInstance.apiKnowledgeEntriesByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeEntriesApi#apiV2KnowledgeEntriesByIdGet");
+    System.err.println("Exception when calling KnowledgeEntriesApi#apiKnowledgeEntriesByIdGet");
     e.printStackTrace();
 }
 ```
@@ -94,9 +94,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeEntriesByIdPut"></a>
-# **apiV2KnowledgeEntriesByIdPut**
-> apiV2KnowledgeEntriesByIdPut(id, record)
+<a name="apiKnowledgeEntriesByIdPut"></a>
+# **apiKnowledgeEntriesByIdPut**
+> apiKnowledgeEntriesByIdPut(id, record)
 
 Update an existing knowledge entry.
 
@@ -111,9 +111,9 @@ KnowledgeEntriesApi apiInstance = new KnowledgeEntriesApi();
 UUID id = new UUID(); // UUID | 
 KnowledgeEntryRecord record = new KnowledgeEntryRecord(); // KnowledgeEntryRecord | 
 try {
-    apiInstance.apiV2KnowledgeEntriesByIdPut(id, record);
+    apiInstance.apiKnowledgeEntriesByIdPut(id, record);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeEntriesApi#apiV2KnowledgeEntriesByIdPut");
+    System.err.println("Exception when calling KnowledgeEntriesApi#apiKnowledgeEntriesByIdPut");
     e.printStackTrace();
 }
 ```
@@ -138,9 +138,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeEntriesGet"></a>
-# **apiV2KnowledgeEntriesGet**
-> List&lt;KnowledgeEntryRecord&gt; apiV2KnowledgeEntriesGet()
+<a name="apiKnowledgeEntriesGet"></a>
+# **apiKnowledgeEntriesGet**
+> List&lt;KnowledgeEntryRecord&gt; apiKnowledgeEntriesGet()
 
 Retrieves a list of all knowledge entries.
 
@@ -151,10 +151,10 @@ Retrieves a list of all knowledge entries.
 
 KnowledgeEntriesApi apiInstance = new KnowledgeEntriesApi();
 try {
-    List<KnowledgeEntryRecord> result = apiInstance.apiV2KnowledgeEntriesGet();
+    List<KnowledgeEntryRecord> result = apiInstance.apiKnowledgeEntriesGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeEntriesApi#apiV2KnowledgeEntriesGet");
+    System.err.println("Exception when calling KnowledgeEntriesApi#apiKnowledgeEntriesGet");
     e.printStackTrace();
 }
 ```
@@ -175,9 +175,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeEntriesPost"></a>
-# **apiV2KnowledgeEntriesPost**
-> UUID apiV2KnowledgeEntriesPost(record)
+<a name="apiKnowledgeEntriesPost"></a>
+# **apiKnowledgeEntriesPost**
+> UUID apiKnowledgeEntriesPost(record)
 
 Create a new knowledge entry.
 
@@ -191,10 +191,10 @@ Create a new knowledge entry.
 KnowledgeEntriesApi apiInstance = new KnowledgeEntriesApi();
 KnowledgeEntryRecord record = new KnowledgeEntryRecord(); // KnowledgeEntryRecord | 
 try {
-    UUID result = apiInstance.apiV2KnowledgeEntriesPost(record);
+    UUID result = apiInstance.apiKnowledgeEntriesPost(record);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeEntriesApi#apiV2KnowledgeEntriesPost");
+    System.err.println("Exception when calling KnowledgeEntriesApi#apiKnowledgeEntriesPost");
     e.printStackTrace();
 }
 ```

--- a/app/docs/KnowledgeEntryRecord.md
+++ b/app/docs/KnowledgeEntryRecord.md
@@ -4,12 +4,12 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
-**knowledgeGroupId** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
+**knowledgeGroupId** | [**UUID**](UUID.md) |  | 
 **title** | **String** |  | 
 **text** | **String** |  | 
-**order** | **Integer** |  |  [optional]
+**order** | **Integer** |  | 
 **links** | [**List&lt;LinkFragment&gt;**](LinkFragment.md) |  |  [optional]
 **imageIds** | [**List&lt;UUID&gt;**](UUID.md) |  |  [optional]
 

--- a/app/docs/KnowledgeGroupRecord.md
+++ b/app/docs/KnowledgeGroupRecord.md
@@ -4,11 +4,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **name** | **String** |  | 
 **description** | **String** |  | 
-**order** | **Integer** |  |  [optional]
+**order** | **Integer** |  | 
 **showInHamburgerMenu** | **Boolean** |  |  [optional]
 **fontAwesomeIconCharacterUnicodeAddress** | **String** |  |  [optional]
 

--- a/app/docs/KnowledgeGroupsApi.md
+++ b/app/docs/KnowledgeGroupsApi.md
@@ -4,16 +4,16 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2KnowledgeGroupsByIdDelete**](KnowledgeGroupsApi.md#apiV2KnowledgeGroupsByIdDelete) | **DELETE** /Api/v2/KnowledgeGroups/{Id} | Delete a knowledge group.
-[**apiV2KnowledgeGroupsByIdGet**](KnowledgeGroupsApi.md#apiV2KnowledgeGroupsByIdGet) | **GET** /Api/v2/KnowledgeGroups/{Id} | Retrieve a single knowledge group.
-[**apiV2KnowledgeGroupsByIdPut**](KnowledgeGroupsApi.md#apiV2KnowledgeGroupsByIdPut) | **PUT** /Api/v2/KnowledgeGroups/{Id} | Update an existing knowledge group.
-[**apiV2KnowledgeGroupsGet**](KnowledgeGroupsApi.md#apiV2KnowledgeGroupsGet) | **GET** /Api/v2/KnowledgeGroups | Retrieves a list of all knowledge groups.
-[**apiV2KnowledgeGroupsPost**](KnowledgeGroupsApi.md#apiV2KnowledgeGroupsPost) | **POST** /Api/v2/KnowledgeGroups | Create a new knowledge group.
+[**apiKnowledgeGroupsByIdDelete**](KnowledgeGroupsApi.md#apiKnowledgeGroupsByIdDelete) | **DELETE** /Api/KnowledgeGroups/{Id} | Delete a knowledge group.
+[**apiKnowledgeGroupsByIdGet**](KnowledgeGroupsApi.md#apiKnowledgeGroupsByIdGet) | **GET** /Api/KnowledgeGroups/{Id} | Retrieve a single knowledge group.
+[**apiKnowledgeGroupsByIdPut**](KnowledgeGroupsApi.md#apiKnowledgeGroupsByIdPut) | **PUT** /Api/KnowledgeGroups/{Id} | Update an existing knowledge group.
+[**apiKnowledgeGroupsGet**](KnowledgeGroupsApi.md#apiKnowledgeGroupsGet) | **GET** /Api/KnowledgeGroups | Retrieves a list of all knowledge groups.
+[**apiKnowledgeGroupsPost**](KnowledgeGroupsApi.md#apiKnowledgeGroupsPost) | **POST** /Api/KnowledgeGroups | Create a new knowledge group.
 
 
-<a name="apiV2KnowledgeGroupsByIdDelete"></a>
-# **apiV2KnowledgeGroupsByIdDelete**
-> apiV2KnowledgeGroupsByIdDelete(id)
+<a name="apiKnowledgeGroupsByIdDelete"></a>
+# **apiKnowledgeGroupsByIdDelete**
+> apiKnowledgeGroupsByIdDelete(id)
 
 Delete a knowledge group.
 
@@ -27,9 +27,9 @@ Delete a knowledge group.
 KnowledgeGroupsApi apiInstance = new KnowledgeGroupsApi();
 UUID id = new UUID(); // UUID | 
 try {
-    apiInstance.apiV2KnowledgeGroupsByIdDelete(id);
+    apiInstance.apiKnowledgeGroupsByIdDelete(id);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeGroupsApi#apiV2KnowledgeGroupsByIdDelete");
+    System.err.println("Exception when calling KnowledgeGroupsApi#apiKnowledgeGroupsByIdDelete");
     e.printStackTrace();
 }
 ```
@@ -53,9 +53,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeGroupsByIdGet"></a>
-# **apiV2KnowledgeGroupsByIdGet**
-> KnowledgeGroupRecord apiV2KnowledgeGroupsByIdGet(id)
+<a name="apiKnowledgeGroupsByIdGet"></a>
+# **apiKnowledgeGroupsByIdGet**
+> KnowledgeGroupRecord apiKnowledgeGroupsByIdGet(id)
 
 Retrieve a single knowledge group.
 
@@ -67,10 +67,10 @@ Retrieve a single knowledge group.
 KnowledgeGroupsApi apiInstance = new KnowledgeGroupsApi();
 UUID id = new UUID(); // UUID | id of the requested entity
 try {
-    KnowledgeGroupRecord result = apiInstance.apiV2KnowledgeGroupsByIdGet(id);
+    KnowledgeGroupRecord result = apiInstance.apiKnowledgeGroupsByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeGroupsApi#apiV2KnowledgeGroupsByIdGet");
+    System.err.println("Exception when calling KnowledgeGroupsApi#apiKnowledgeGroupsByIdGet");
     e.printStackTrace();
 }
 ```
@@ -94,9 +94,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeGroupsByIdPut"></a>
-# **apiV2KnowledgeGroupsByIdPut**
-> apiV2KnowledgeGroupsByIdPut(id, record)
+<a name="apiKnowledgeGroupsByIdPut"></a>
+# **apiKnowledgeGroupsByIdPut**
+> apiKnowledgeGroupsByIdPut(id, record)
 
 Update an existing knowledge group.
 
@@ -111,9 +111,9 @@ KnowledgeGroupsApi apiInstance = new KnowledgeGroupsApi();
 UUID id = new UUID(); // UUID | 
 KnowledgeGroupRecord record = new KnowledgeGroupRecord(); // KnowledgeGroupRecord | 
 try {
-    apiInstance.apiV2KnowledgeGroupsByIdPut(id, record);
+    apiInstance.apiKnowledgeGroupsByIdPut(id, record);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeGroupsApi#apiV2KnowledgeGroupsByIdPut");
+    System.err.println("Exception when calling KnowledgeGroupsApi#apiKnowledgeGroupsByIdPut");
     e.printStackTrace();
 }
 ```
@@ -138,9 +138,9 @@ null (empty response body)
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeGroupsGet"></a>
-# **apiV2KnowledgeGroupsGet**
-> List&lt;KnowledgeGroupRecord&gt; apiV2KnowledgeGroupsGet()
+<a name="apiKnowledgeGroupsGet"></a>
+# **apiKnowledgeGroupsGet**
+> List&lt;KnowledgeGroupRecord&gt; apiKnowledgeGroupsGet()
 
 Retrieves a list of all knowledge groups.
 
@@ -151,10 +151,10 @@ Retrieves a list of all knowledge groups.
 
 KnowledgeGroupsApi apiInstance = new KnowledgeGroupsApi();
 try {
-    List<KnowledgeGroupRecord> result = apiInstance.apiV2KnowledgeGroupsGet();
+    List<KnowledgeGroupRecord> result = apiInstance.apiKnowledgeGroupsGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeGroupsApi#apiV2KnowledgeGroupsGet");
+    System.err.println("Exception when calling KnowledgeGroupsApi#apiKnowledgeGroupsGet");
     e.printStackTrace();
 }
 ```
@@ -175,9 +175,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2KnowledgeGroupsPost"></a>
-# **apiV2KnowledgeGroupsPost**
-> UUID apiV2KnowledgeGroupsPost(record)
+<a name="apiKnowledgeGroupsPost"></a>
+# **apiKnowledgeGroupsPost**
+> UUID apiKnowledgeGroupsPost(record)
 
 Create a new knowledge group.
 
@@ -191,10 +191,10 @@ Create a new knowledge group.
 KnowledgeGroupsApi apiInstance = new KnowledgeGroupsApi();
 KnowledgeGroupRecord record = new KnowledgeGroupRecord(); // KnowledgeGroupRecord | 
 try {
-    UUID result = apiInstance.apiV2KnowledgeGroupsPost(record);
+    UUID result = apiInstance.apiKnowledgeGroupsPost(record);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling KnowledgeGroupsApi#apiV2KnowledgeGroupsPost");
+    System.err.println("Exception when calling KnowledgeGroupsApi#apiKnowledgeGroupsPost");
     e.printStackTrace();
 }
 ```

--- a/app/docs/LinkFragment.md
+++ b/app/docs/LinkFragment.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**fragmentType** | [**FragmentTypeEnum**](#FragmentTypeEnum) |  |  [optional]
+**fragmentType** | [**FragmentTypeEnum**](#FragmentTypeEnum) |  | 
 **name** | **String** |  |  [optional]
 **target** | **String** | * For FragmentType &#x60;DealerDetail&#x60;: The &#x60;Id&#x60; of the dealer record the link is referencing to.  * For FragmentType &#x60;MapEntry&#x60;: The &#x60;Id&#x60; of the map entry record the link is referencing to.  * For FragmentType &#x60;EventConferenceRoom&#x60;: The &#x60;Id&#x60; of the event conference room record the link is referencing to.  * For FragmentType &#x60;MapExternal&#x60;: An stringified json object.    * Acceptable properties and their expected value (type):      * &#x60;name&#x60; - name of target POI (*string*)      * &#x60;street&#x60; - street name (*string*)      * &#x60;house&#x60; - house humber (*string*)      * &#x60;zip&#x60; - zip code of city (*string*)      * &#x60;city&#x60; - city (*string*)      * &#x60;country&#x60; - country (*string*)      * &#x60;country-a3&#x60; - ISO 3166-1 alpha-3 code for country [http://unstats.un.org/unsd/methods/m49/m49alpha.htm] (*string*)      * &#x60;lat&#x60; - latitude (*decimal*)      * &#x60;lon&#x60; - longitude (*decimal*)    * Example:      * &#x60;{ name: \&quot;Estrel Hotel Berlin\&quot;, house: \&quot;225\&quot;, street: \&quot;Sonnenallee\&quot;, zip: \&quot;12057\&quot;, city: \&quot;Berlin\&quot;, country: \&quot;Germany\&quot;, lat: 52.473336, lon: 13.458729 }&#x60; | 
 

--- a/app/docs/MapEntryRecord.md
+++ b/app/docs/MapEntryRecord.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**id** | [**UUID**](UUID.md) |  | 
 **X** | **Integer** | \&quot;X\&quot; coordinate of the *center* of a *circular area*, expressed in pixels. |  [optional]
 **Y** | **Integer** | \&quot;Y\&quot; coordinate of the *center* of a *circular area*, expressed in pixels. |  [optional]
 **tapRadius** | **Integer** | \&quot;Radius\&quot; of a *circular area* (the center of which described with X and Y), expressed in pixels. |  [optional]

--- a/app/docs/MapRecord.md
+++ b/app/docs/MapRecord.md
@@ -4,11 +4,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
-**imageId** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
+**imageId** | [**UUID**](UUID.md) |  | 
 **description** | **String** |  | 
-**isBrowseable** | **Boolean** |  |  [optional]
+**isBrowseable** | **Boolean** |  | 
 **entries** | [**List&lt;MapEntryRecord&gt;**](MapEntryRecord.md) |  | 
 
 

--- a/app/docs/MapsApi.md
+++ b/app/docs/MapsApi.md
@@ -4,19 +4,19 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2MapsByIdEntriesByEntryIdDelete**](MapsApi.md#apiV2MapsByIdEntriesByEntryIdDelete) | **DELETE** /Api/v2/Maps/{Id}/Entries/{EntryId} | Delete a specific map entry for a specific map
-[**apiV2MapsByIdEntriesByEntryIdGet**](MapsApi.md#apiV2MapsByIdEntriesByEntryIdGet) | **GET** /Api/v2/Maps/{Id}/Entries/{EntryId} | Get all specific map entry for a specific map
-[**apiV2MapsByIdEntriesByEntryIdPut**](MapsApi.md#apiV2MapsByIdEntriesByEntryIdPut) | **PUT** /Api/v2/Maps/{Id}/Entries/{EntryId} | Create or Update an existing map entry in a specific map
-[**apiV2MapsByIdEntriesDelete**](MapsApi.md#apiV2MapsByIdEntriesDelete) | **DELETE** /Api/v2/Maps/{Id}/Entries | Delete all map entries for a specific map
-[**apiV2MapsByIdEntriesGet**](MapsApi.md#apiV2MapsByIdEntriesGet) | **GET** /Api/v2/Maps/{Id}/Entries | Get all map entries for a specific map
-[**apiV2MapsByIdEntriesPost**](MapsApi.md#apiV2MapsByIdEntriesPost) | **POST** /Api/v2/Maps/{Id}/Entries | Create a new map entry in a specific map
-[**apiV2MapsByIdGet**](MapsApi.md#apiV2MapsByIdGet) | **GET** /Api/v2/Maps/{Id} | Get a specific map
-[**apiV2MapsGet**](MapsApi.md#apiV2MapsGet) | **GET** /Api/v2/Maps | Get all maps
+[**apiMapsByIdEntriesByEntryIdDelete**](MapsApi.md#apiMapsByIdEntriesByEntryIdDelete) | **DELETE** /Api/Maps/{Id}/Entries/{EntryId} | Delete a specific map entry for a specific map
+[**apiMapsByIdEntriesByEntryIdGet**](MapsApi.md#apiMapsByIdEntriesByEntryIdGet) | **GET** /Api/Maps/{Id}/Entries/{EntryId} | Get all specific map entry for a specific map
+[**apiMapsByIdEntriesByEntryIdPut**](MapsApi.md#apiMapsByIdEntriesByEntryIdPut) | **PUT** /Api/Maps/{Id}/Entries/{EntryId} | Create or Update an existing map entry in a specific map
+[**apiMapsByIdEntriesDelete**](MapsApi.md#apiMapsByIdEntriesDelete) | **DELETE** /Api/Maps/{Id}/Entries | Delete all map entries for a specific map
+[**apiMapsByIdEntriesGet**](MapsApi.md#apiMapsByIdEntriesGet) | **GET** /Api/Maps/{Id}/Entries | Get all map entries for a specific map
+[**apiMapsByIdEntriesPost**](MapsApi.md#apiMapsByIdEntriesPost) | **POST** /Api/Maps/{Id}/Entries | Create a new map entry in a specific map
+[**apiMapsByIdGet**](MapsApi.md#apiMapsByIdGet) | **GET** /Api/Maps/{Id} | Get a specific map
+[**apiMapsGet**](MapsApi.md#apiMapsGet) | **GET** /Api/Maps | Get all maps
 
 
-<a name="apiV2MapsByIdEntriesByEntryIdDelete"></a>
-# **apiV2MapsByIdEntriesByEntryIdDelete**
-> apiV2MapsByIdEntriesByEntryIdDelete(id, entryId)
+<a name="apiMapsByIdEntriesByEntryIdDelete"></a>
+# **apiMapsByIdEntriesByEntryIdDelete**
+> apiMapsByIdEntriesByEntryIdDelete(id, entryId)
 
 Delete a specific map entry for a specific map
 
@@ -31,9 +31,9 @@ MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | 
 UUID entryId = new UUID(); // UUID | 
 try {
-    apiInstance.apiV2MapsByIdEntriesByEntryIdDelete(id, entryId);
+    apiInstance.apiMapsByIdEntriesByEntryIdDelete(id, entryId);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesByEntryIdDelete");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesByEntryIdDelete");
     e.printStackTrace();
 }
 ```
@@ -58,9 +58,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2MapsByIdEntriesByEntryIdGet"></a>
-# **apiV2MapsByIdEntriesByEntryIdGet**
-> MapEntryRecord apiV2MapsByIdEntriesByEntryIdGet(id, entryId)
+<a name="apiMapsByIdEntriesByEntryIdGet"></a>
+# **apiMapsByIdEntriesByEntryIdGet**
+> MapEntryRecord apiMapsByIdEntriesByEntryIdGet(id, entryId)
 
 Get all specific map entry for a specific map
 
@@ -73,10 +73,10 @@ MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | 
 UUID entryId = new UUID(); // UUID | 
 try {
-    MapEntryRecord result = apiInstance.apiV2MapsByIdEntriesByEntryIdGet(id, entryId);
+    MapEntryRecord result = apiInstance.apiMapsByIdEntriesByEntryIdGet(id, entryId);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesByEntryIdGet");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesByEntryIdGet");
     e.printStackTrace();
 }
 ```
@@ -101,9 +101,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2MapsByIdEntriesByEntryIdPut"></a>
-# **apiV2MapsByIdEntriesByEntryIdPut**
-> UUID apiV2MapsByIdEntriesByEntryIdPut(id, entryId, record)
+<a name="apiMapsByIdEntriesByEntryIdPut"></a>
+# **apiMapsByIdEntriesByEntryIdPut**
+> UUID apiMapsByIdEntriesByEntryIdPut(id, entryId, record)
 
 Create or Update an existing map entry in a specific map
 
@@ -119,10 +119,10 @@ UUID id = new UUID(); // UUID | \"Id\" of the map.
 UUID entryId = new UUID(); // UUID | \"Id\" of the entry that gets inserted.
 MapEntryRecord record = new MapEntryRecord(); // MapEntryRecord | \"Id\" property must match the {EntryId} part of the uri
 try {
-    UUID result = apiInstance.apiV2MapsByIdEntriesByEntryIdPut(id, entryId, record);
+    UUID result = apiInstance.apiMapsByIdEntriesByEntryIdPut(id, entryId, record);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesByEntryIdPut");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesByEntryIdPut");
     e.printStackTrace();
 }
 ```
@@ -148,9 +148,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2MapsByIdEntriesDelete"></a>
-# **apiV2MapsByIdEntriesDelete**
-> apiV2MapsByIdEntriesDelete(id)
+<a name="apiMapsByIdEntriesDelete"></a>
+# **apiMapsByIdEntriesDelete**
+> apiMapsByIdEntriesDelete(id)
 
 Delete all map entries for a specific map
 
@@ -164,9 +164,9 @@ Delete all map entries for a specific map
 MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | 
 try {
-    apiInstance.apiV2MapsByIdEntriesDelete(id);
+    apiInstance.apiMapsByIdEntriesDelete(id);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesDelete");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesDelete");
     e.printStackTrace();
 }
 ```
@@ -190,9 +190,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2MapsByIdEntriesGet"></a>
-# **apiV2MapsByIdEntriesGet**
-> List&lt;MapEntryRecord&gt; apiV2MapsByIdEntriesGet(id)
+<a name="apiMapsByIdEntriesGet"></a>
+# **apiMapsByIdEntriesGet**
+> List&lt;MapEntryRecord&gt; apiMapsByIdEntriesGet(id)
 
 Get all map entries for a specific map
 
@@ -204,10 +204,10 @@ Get all map entries for a specific map
 MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | 
 try {
-    List<MapEntryRecord> result = apiInstance.apiV2MapsByIdEntriesGet(id);
+    List<MapEntryRecord> result = apiInstance.apiMapsByIdEntriesGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesGet");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesGet");
     e.printStackTrace();
 }
 ```
@@ -231,9 +231,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2MapsByIdEntriesPost"></a>
-# **apiV2MapsByIdEntriesPost**
-> UUID apiV2MapsByIdEntriesPost(id, record)
+<a name="apiMapsByIdEntriesPost"></a>
+# **apiMapsByIdEntriesPost**
+> UUID apiMapsByIdEntriesPost(id, record)
 
 Create a new map entry in a specific map
 
@@ -248,10 +248,10 @@ MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | \"Id\" of the map
 MapEntryRecord record = new MapEntryRecord(); // MapEntryRecord | Do not specify the \"Id\" property. It will be auto-assigned and returned in the response.
 try {
-    UUID result = apiInstance.apiV2MapsByIdEntriesPost(id, record);
+    UUID result = apiInstance.apiMapsByIdEntriesPost(id, record);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdEntriesPost");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdEntriesPost");
     e.printStackTrace();
 }
 ```
@@ -276,9 +276,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2MapsByIdGet"></a>
-# **apiV2MapsByIdGet**
-> MapRecord apiV2MapsByIdGet(id)
+<a name="apiMapsByIdGet"></a>
+# **apiMapsByIdGet**
+> MapRecord apiMapsByIdGet(id)
 
 Get a specific map
 
@@ -290,10 +290,10 @@ Get a specific map
 MapsApi apiInstance = new MapsApi();
 UUID id = new UUID(); // UUID | 
 try {
-    MapRecord result = apiInstance.apiV2MapsByIdGet(id);
+    MapRecord result = apiInstance.apiMapsByIdGet(id);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsByIdGet");
+    System.err.println("Exception when calling MapsApi#apiMapsByIdGet");
     e.printStackTrace();
 }
 ```
@@ -317,9 +317,9 @@ No authorization required
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2MapsGet"></a>
-# **apiV2MapsGet**
-> List&lt;MapRecord&gt; apiV2MapsGet()
+<a name="apiMapsGet"></a>
+# **apiMapsGet**
+> List&lt;MapRecord&gt; apiMapsGet()
 
 Get all maps
 
@@ -330,10 +330,10 @@ Get all maps
 
 MapsApi apiInstance = new MapsApi();
 try {
-    List<MapRecord> result = apiInstance.apiV2MapsGet();
+    List<MapRecord> result = apiInstance.apiMapsGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling MapsApi#apiV2MapsGet");
+    System.err.println("Exception when calling MapsApi#apiMapsGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/PrivateMessageRecord.md
+++ b/app/docs/PrivateMessageRecord.md
@@ -4,10 +4,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lastChangeDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
-**id** | [**UUID**](UUID.md) |  |  [optional]
+**lastChangeDateTimeUtc** | [**Date**](Date.md) |  | 
+**id** | [**UUID**](UUID.md) |  | 
 **recipientUid** | **String** |  | 
-**createdDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
+**senderUid** | **String** |  |  [optional]
+**createdDateTimeUtc** | [**Date**](Date.md) |  | 
 **receivedDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
 **readDateTimeUtc** | [**Date**](Date.md) |  |  [optional]
 **authorName** | **String** |  |  [optional]

--- a/app/docs/PushNotificationsApi.md
+++ b/app/docs/PushNotificationsApi.md
@@ -4,16 +4,16 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2PushNotificationsFcmDeviceRegistrationPost**](PushNotificationsApi.md#apiV2PushNotificationsFcmDeviceRegistrationPost) | **POST** /Api/v2/PushNotifications/FcmDeviceRegistration | 
-[**apiV2PushNotificationsStatisticsGet**](PushNotificationsApi.md#apiV2PushNotificationsStatisticsGet) | **GET** /Api/v2/PushNotifications/Statistics | 
-[**apiV2PushNotificationsSyncRequestPost**](PushNotificationsApi.md#apiV2PushNotificationsSyncRequestPost) | **POST** /Api/v2/PushNotifications/SyncRequest | 
-[**apiV2PushNotificationsWnsChannelRegistrationPost**](PushNotificationsApi.md#apiV2PushNotificationsWnsChannelRegistrationPost) | **POST** /Api/v2/PushNotifications/WnsChannelRegistration | 
-[**apiV2PushNotificationsWnsToastPost**](PushNotificationsApi.md#apiV2PushNotificationsWnsToastPost) | **POST** /Api/v2/PushNotifications/WnsToast | 
+[**apiPushNotificationsFcmDeviceRegistrationPost**](PushNotificationsApi.md#apiPushNotificationsFcmDeviceRegistrationPost) | **POST** /Api/PushNotifications/FcmDeviceRegistration | 
+[**apiPushNotificationsStatisticsGet**](PushNotificationsApi.md#apiPushNotificationsStatisticsGet) | **GET** /Api/PushNotifications/Statistics | 
+[**apiPushNotificationsSyncRequestPost**](PushNotificationsApi.md#apiPushNotificationsSyncRequestPost) | **POST** /Api/PushNotifications/SyncRequest | 
+[**apiPushNotificationsWnsChannelRegistrationPost**](PushNotificationsApi.md#apiPushNotificationsWnsChannelRegistrationPost) | **POST** /Api/PushNotifications/WnsChannelRegistration | 
+[**apiPushNotificationsWnsToastPost**](PushNotificationsApi.md#apiPushNotificationsWnsToastPost) | **POST** /Api/PushNotifications/WnsToast | 
 
 
-<a name="apiV2PushNotificationsFcmDeviceRegistrationPost"></a>
-# **apiV2PushNotificationsFcmDeviceRegistrationPost**
-> apiV2PushNotificationsFcmDeviceRegistrationPost(request)
+<a name="apiPushNotificationsFcmDeviceRegistrationPost"></a>
+# **apiPushNotificationsFcmDeviceRegistrationPost**
+> apiPushNotificationsFcmDeviceRegistrationPost(request)
 
 
 
@@ -25,9 +25,9 @@ Method | HTTP request | Description
 PushNotificationsApi apiInstance = new PushNotificationsApi();
 PostFcmDeviceRegistrationRequest request = new PostFcmDeviceRegistrationRequest(); // PostFcmDeviceRegistrationRequest | 
 try {
-    apiInstance.apiV2PushNotificationsFcmDeviceRegistrationPost(request);
+    apiInstance.apiPushNotificationsFcmDeviceRegistrationPost(request);
 } catch (ApiException e) {
-    System.err.println("Exception when calling PushNotificationsApi#apiV2PushNotificationsFcmDeviceRegistrationPost");
+    System.err.println("Exception when calling PushNotificationsApi#apiPushNotificationsFcmDeviceRegistrationPost");
     e.printStackTrace();
 }
 ```
@@ -51,9 +51,9 @@ No authorization required
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: Not defined
 
-<a name="apiV2PushNotificationsStatisticsGet"></a>
-# **apiV2PushNotificationsStatisticsGet**
-> PushNotificationChannelStatistics apiV2PushNotificationsStatisticsGet(since)
+<a name="apiPushNotificationsStatisticsGet"></a>
+# **apiPushNotificationsStatisticsGet**
+> PushNotificationChannelStatistics apiPushNotificationsStatisticsGet(since)
 
 
 
@@ -67,10 +67,10 @@ No authorization required
 PushNotificationsApi apiInstance = new PushNotificationsApi();
 Date since = new Date(); // Date | 
 try {
-    PushNotificationChannelStatistics result = apiInstance.apiV2PushNotificationsStatisticsGet(since);
+    PushNotificationChannelStatistics result = apiInstance.apiPushNotificationsStatisticsGet(since);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling PushNotificationsApi#apiV2PushNotificationsStatisticsGet");
+    System.err.println("Exception when calling PushNotificationsApi#apiPushNotificationsStatisticsGet");
     e.printStackTrace();
 }
 ```
@@ -94,9 +94,9 @@ Name | Type | Description  | Notes
  - **Content-Type**: Not defined
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2PushNotificationsSyncRequestPost"></a>
-# **apiV2PushNotificationsSyncRequestPost**
-> apiV2PushNotificationsSyncRequestPost()
+<a name="apiPushNotificationsSyncRequestPost"></a>
+# **apiPushNotificationsSyncRequestPost**
+> apiPushNotificationsSyncRequestPost()
 
 
 
@@ -109,9 +109,9 @@ Name | Type | Description  | Notes
 
 PushNotificationsApi apiInstance = new PushNotificationsApi();
 try {
-    apiInstance.apiV2PushNotificationsSyncRequestPost();
+    apiInstance.apiPushNotificationsSyncRequestPost();
 } catch (ApiException e) {
-    System.err.println("Exception when calling PushNotificationsApi#apiV2PushNotificationsSyncRequestPost");
+    System.err.println("Exception when calling PushNotificationsApi#apiPushNotificationsSyncRequestPost");
     e.printStackTrace();
 }
 ```
@@ -132,9 +132,9 @@ null (empty response body)
  - **Content-Type**: Not defined
  - **Accept**: Not defined
 
-<a name="apiV2PushNotificationsWnsChannelRegistrationPost"></a>
-# **apiV2PushNotificationsWnsChannelRegistrationPost**
-> apiV2PushNotificationsWnsChannelRegistrationPost(request)
+<a name="apiPushNotificationsWnsChannelRegistrationPost"></a>
+# **apiPushNotificationsWnsChannelRegistrationPost**
+> apiPushNotificationsWnsChannelRegistrationPost(request)
 
 
 
@@ -146,9 +146,9 @@ null (empty response body)
 PushNotificationsApi apiInstance = new PushNotificationsApi();
 PostWnsChannelRegistrationRequest request = new PostWnsChannelRegistrationRequest(); // PostWnsChannelRegistrationRequest | 
 try {
-    apiInstance.apiV2PushNotificationsWnsChannelRegistrationPost(request);
+    apiInstance.apiPushNotificationsWnsChannelRegistrationPost(request);
 } catch (ApiException e) {
-    System.err.println("Exception when calling PushNotificationsApi#apiV2PushNotificationsWnsChannelRegistrationPost");
+    System.err.println("Exception when calling PushNotificationsApi#apiPushNotificationsWnsChannelRegistrationPost");
     e.printStackTrace();
 }
 ```
@@ -172,9 +172,9 @@ No authorization required
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: Not defined
 
-<a name="apiV2PushNotificationsWnsToastPost"></a>
-# **apiV2PushNotificationsWnsToastPost**
-> apiV2PushNotificationsWnsToastPost(request)
+<a name="apiPushNotificationsWnsToastPost"></a>
+# **apiPushNotificationsWnsToastPost**
+> apiPushNotificationsWnsToastPost(request)
 
 
 
@@ -188,9 +188,9 @@ No authorization required
 PushNotificationsApi apiInstance = new PushNotificationsApi();
 ToastTest request = new ToastTest(); // ToastTest | 
 try {
-    apiInstance.apiV2PushNotificationsWnsToastPost(request);
+    apiInstance.apiPushNotificationsWnsToastPost(request);
 } catch (ApiException e) {
-    System.err.println("Exception when calling PushNotificationsApi#apiV2PushNotificationsWnsToastPost");
+    System.err.println("Exception when calling PushNotificationsApi#apiPushNotificationsWnsToastPost");
     e.printStackTrace();
 }
 ```

--- a/app/docs/SyncApi.md
+++ b/app/docs/SyncApi.md
@@ -4,12 +4,12 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2SyncGet**](SyncApi.md#apiV2SyncGet) | **GET** /Api/v2/Sync | Returns everything you could ever wish for.
+[**apiSyncGet**](SyncApi.md#apiSyncGet) | **GET** /Api/Sync | Returns everything you could ever wish for.
 
 
-<a name="apiV2SyncGet"></a>
-# **apiV2SyncGet**
-> AggregatedDeltaResponse apiV2SyncGet(since)
+<a name="apiSyncGet"></a>
+# **apiSyncGet**
+> AggregatedDeltaResponse apiSyncGet(since)
 
 Returns everything you could ever wish for.
 
@@ -21,10 +21,10 @@ Returns everything you could ever wish for.
 SyncApi apiInstance = new SyncApi();
 Date since = new Date(); // Date | 
 try {
-    AggregatedDeltaResponse result = apiInstance.apiV2SyncGet(since);
+    AggregatedDeltaResponse result = apiInstance.apiSyncGet(since);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling SyncApi#apiV2SyncGet");
+    System.err.println("Exception when calling SyncApi#apiSyncGet");
     e.printStackTrace();
 }
 ```

--- a/app/docs/TokensApi.md
+++ b/app/docs/TokensApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *https://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**apiV2TokensRegSysPost**](TokensApi.md#apiV2TokensRegSysPost) | **POST** /Api/v2/Tokens/RegSys | 
-[**apiV2TokensWhoAmIGet**](TokensApi.md#apiV2TokensWhoAmIGet) | **GET** /Api/v2/Tokens/WhoAmI | 
+[**apiTokensRegSysPost**](TokensApi.md#apiTokensRegSysPost) | **POST** /Api/Tokens/RegSys | 
+[**apiTokensWhoAmIGet**](TokensApi.md#apiTokensWhoAmIGet) | **GET** /Api/Tokens/WhoAmI | 
 
 
-<a name="apiV2TokensRegSysPost"></a>
-# **apiV2TokensRegSysPost**
-> AuthenticationResponse apiV2TokensRegSysPost(request)
+<a name="apiTokensRegSysPost"></a>
+# **apiTokensRegSysPost**
+> AuthenticationResponse apiTokensRegSysPost(request)
 
 
 
@@ -22,10 +22,10 @@ Method | HTTP request | Description
 TokensApi apiInstance = new TokensApi();
 RegSysAuthenticationRequest request = new RegSysAuthenticationRequest(); // RegSysAuthenticationRequest | 
 try {
-    AuthenticationResponse result = apiInstance.apiV2TokensRegSysPost(request);
+    AuthenticationResponse result = apiInstance.apiTokensRegSysPost(request);
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling TokensApi#apiV2TokensRegSysPost");
+    System.err.println("Exception when calling TokensApi#apiTokensRegSysPost");
     e.printStackTrace();
 }
 ```
@@ -49,9 +49,9 @@ No authorization required
  - **Content-Type**: application/json-patch+json, application/json, text/json, application/*+json
  - **Accept**: text/plain, application/json, text/json
 
-<a name="apiV2TokensWhoAmIGet"></a>
-# **apiV2TokensWhoAmIGet**
-> AuthenticationResponse apiV2TokensWhoAmIGet()
+<a name="apiTokensWhoAmIGet"></a>
+# **apiTokensWhoAmIGet**
+> AuthenticationResponse apiTokensWhoAmIGet()
 
 
 
@@ -64,10 +64,10 @@ No authorization required
 
 TokensApi apiInstance = new TokensApi();
 try {
-    AuthenticationResponse result = apiInstance.apiV2TokensWhoAmIGet();
+    AuthenticationResponse result = apiInstance.apiTokensWhoAmIGet();
     System.out.println(result);
 } catch (ApiException e) {
-    System.err.println("Exception when calling TokensApi#apiV2TokensWhoAmIGet");
+    System.err.println("Exception when calling TokensApi#apiTokensWhoAmIGet");
     e.printStackTrace();
 }
 ```

--- a/app/src/main/java/io/swagger/client/api/AnnouncementsApi.java
+++ b/app/src/main/java/io/swagger/client/api/AnnouncementsApi.java
@@ -50,18 +50,18 @@ public class AnnouncementsApi {
    * @param id 
    * @return void
   */
-  public void apiV2AnnouncementsByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiAnnouncementsByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2AnnouncementsByIdDelete",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2AnnouncementsByIdDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiAnnouncementsByIdDelete",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiAnnouncementsByIdDelete"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class AnnouncementsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param id 
   */
-  public void apiV2AnnouncementsByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2AnnouncementsByIdDelete",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2AnnouncementsByIdDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiAnnouncementsByIdDelete",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiAnnouncementsByIdDelete"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -183,18 +183,18 @@ public class AnnouncementsApi {
    * @param id id of the requested entity
    * @return AnnouncementRecord
   */
-  public AnnouncementRecord apiV2AnnouncementsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public AnnouncementRecord apiAnnouncementsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2AnnouncementsByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2AnnouncementsByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiAnnouncementsByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiAnnouncementsByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -252,19 +252,19 @@ public class AnnouncementsApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2AnnouncementsByIdGet (UUID id, final Response.Listener<AnnouncementRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsByIdGet (UUID id, final Response.Listener<AnnouncementRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2AnnouncementsByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2AnnouncementsByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiAnnouncementsByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiAnnouncementsByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Announcements/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -319,12 +319,12 @@ public class AnnouncementsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @return void
   */
-  public void apiV2AnnouncementsDelete () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiAnnouncementsDelete () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+  String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -382,13 +382,13 @@ public class AnnouncementsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
 
   */
-  public void apiV2AnnouncementsDelete (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsDelete (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+    String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -439,12 +439,12 @@ public class AnnouncementsApi {
   * 
    * @return List<AnnouncementRecord>
   */
-  public List<AnnouncementRecord> apiV2AnnouncementsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<AnnouncementRecord> apiAnnouncementsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+  String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -502,13 +502,13 @@ public class AnnouncementsApi {
    * 
 
   */
-  public void apiV2AnnouncementsGet (final Response.Listener<List<AnnouncementRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsGet (final Response.Listener<List<AnnouncementRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+    String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -564,12 +564,12 @@ public class AnnouncementsApi {
    * @param record 
    * @return void
   */
-  public void apiV2AnnouncementsPost (AnnouncementRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiAnnouncementsPost (AnnouncementRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+  String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -627,13 +627,13 @@ public class AnnouncementsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param record 
   */
-  public void apiV2AnnouncementsPost (AnnouncementRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsPost (AnnouncementRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+    String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -685,12 +685,12 @@ public class AnnouncementsApi {
    * @param record 
    * @return void
   */
-  public void apiV2AnnouncementsPut (AnnouncementRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiAnnouncementsPut (AnnouncementRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
 
   // create path and map variables
-  String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+  String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -748,13 +748,13 @@ public class AnnouncementsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param record 
   */
-  public void apiV2AnnouncementsPut (AnnouncementRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiAnnouncementsPut (AnnouncementRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Announcements".replaceAll("\\{format\\}","json");
+    String path = "/Api/Announcements".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/ArtShowApi.java
+++ b/app/src/main/java/io/swagger/client/api/ArtShowApi.java
@@ -48,18 +48,18 @@ public class ArtShowApi {
    * @param payload Art show log contents
    * @return void
   */
-  public void apiV2ArtShowItemActivitesLogPost (byte[] payload) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiArtShowItemActivitesLogPost (byte[] payload) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = payload;
   
       // verify the required parameter 'payload' is set
       if (payload == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'payload' when calling apiV2ArtShowItemActivitesLogPost",
-      new ApiException(400, "Missing the required parameter 'payload' when calling apiV2ArtShowItemActivitesLogPost"));
+      VolleyError error = new VolleyError("Missing the required parameter 'payload' when calling apiArtShowItemActivitesLogPost",
+      new ApiException(400, "Missing the required parameter 'payload' when calling apiArtShowItemActivitesLogPost"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/ArtShow/ItemActivites/Log".replaceAll("\\{format\\}","json");
+  String path = "/Api/ArtShow/ItemActivites/Log".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -117,19 +117,19 @@ public class ArtShowApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param payload Art show log contents
   */
-  public void apiV2ArtShowItemActivitesLogPost (byte[] payload, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiArtShowItemActivitesLogPost (byte[] payload, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = payload;
 
   
     // verify the required parameter 'payload' is set
     if (payload == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'payload' when calling apiV2ArtShowItemActivitesLogPost",
-         new ApiException(400, "Missing the required parameter 'payload' when calling apiV2ArtShowItemActivitesLogPost"));
+       VolleyError error = new VolleyError("Missing the required parameter 'payload' when calling apiArtShowItemActivitesLogPost",
+         new ApiException(400, "Missing the required parameter 'payload' when calling apiArtShowItemActivitesLogPost"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/ArtShow/ItemActivites/Log".replaceAll("\\{format\\}","json");
+    String path = "/Api/ArtShow/ItemActivites/Log".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -180,12 +180,12 @@ public class ArtShowApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @return void
   */
-  public void apiV2ArtShowItemActivitesNotificationBundlesSendPost () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiArtShowItemActivitesNotificationBundlesSendPost () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/ArtShow/ItemActivites/NotificationBundles/Send".replaceAll("\\{format\\}","json");
+  String path = "/Api/ArtShow/ItemActivites/NotificationBundles/Send".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -243,13 +243,13 @@ public class ArtShowApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
 
   */
-  public void apiV2ArtShowItemActivitesNotificationBundlesSendPost (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiArtShowItemActivitesNotificationBundlesSendPost (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/ArtShow/ItemActivites/NotificationBundles/Send".replaceAll("\\{format\\}","json");
+    String path = "/Api/ArtShow/ItemActivites/NotificationBundles/Send".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -300,12 +300,12 @@ public class ArtShowApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @return void
   */
-  public void apiV2ArtShowItemActivitesNotificationBundlesSimulationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiArtShowItemActivitesNotificationBundlesSimulationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/ArtShow/ItemActivites/NotificationBundles/Simulation".replaceAll("\\{format\\}","json");
+  String path = "/Api/ArtShow/ItemActivites/NotificationBundles/Simulation".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -363,13 +363,13 @@ public class ArtShowApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
 
   */
-  public void apiV2ArtShowItemActivitesNotificationBundlesSimulationGet (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiArtShowItemActivitesNotificationBundlesSimulationGet (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/ArtShow/ItemActivites/NotificationBundles/Simulation".replaceAll("\\{format\\}","json");
+    String path = "/Api/ArtShow/ItemActivites/NotificationBundles/Simulation".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/CommunicationApi.java
+++ b/app/src/main/java/io/swagger/client/api/CommunicationApi.java
@@ -51,21 +51,21 @@ public class CommunicationApi {
   * Marks a given private message as read (reading receipt).
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**  Calling this on a message that has already been marked as read  will not update the &#x60;ReadDateTimeUtc&#x60; property, but return the  &#x60;ReadDateTimeUtc&#x60; value of the first call.
    * @param messageId &#x60;Id&#x60; of the message to mark as read
-   * @param isRead 
+   * @param isRead boolean, expected to be &#39;true&#39; always
    * @return Date
   */
-  public Date apiV2CommunicationPrivateMessagesByMessageIdReadPost (UUID messageId, Boolean isRead) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public Date apiCommunicationPrivateMessagesByMessageIdReadPost (UUID messageId, Boolean isRead) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = isRead;
   
       // verify the required parameter 'messageId' is set
       if (messageId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdReadPost",
-      new ApiException(400, "Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdReadPost"));
+      VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdReadPost",
+      new ApiException(400, "Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdReadPost"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Communication/PrivateMessages/{MessageId}/Read".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
+  String path = "/Api/Communication/PrivateMessages/{MessageId}/Read".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -121,21 +121,21 @@ public class CommunicationApi {
       /**
    * Marks a given private message as read (reading receipt).
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**  Calling this on a message that has already been marked as read  will not update the &#x60;ReadDateTimeUtc&#x60; property, but return the  &#x60;ReadDateTimeUtc&#x60; value of the first call.
-   * @param messageId &#x60;Id&#x60; of the message to mark as read   * @param isRead 
+   * @param messageId &#x60;Id&#x60; of the message to mark as read   * @param isRead boolean, expected to be &#39;true&#39; always
   */
-  public void apiV2CommunicationPrivateMessagesByMessageIdReadPost (UUID messageId, Boolean isRead, final Response.Listener<Date> responseListener, final Response.ErrorListener errorListener) {
+  public void apiCommunicationPrivateMessagesByMessageIdReadPost (UUID messageId, Boolean isRead, final Response.Listener<Date> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = isRead;
 
   
     // verify the required parameter 'messageId' is set
     if (messageId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdReadPost",
-         new ApiException(400, "Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdReadPost"));
+       VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdReadPost",
+         new ApiException(400, "Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdReadPost"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Communication/PrivateMessages/{MessageId}/Read".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
+    String path = "/Api/Communication/PrivateMessages/{MessageId}/Read".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -191,18 +191,18 @@ public class CommunicationApi {
    * @param messageId 
    * @return PrivateMessageStatus
   */
-  public PrivateMessageStatus apiV2CommunicationPrivateMessagesByMessageIdStatusGet (UUID messageId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public PrivateMessageStatus apiCommunicationPrivateMessagesByMessageIdStatusGet (UUID messageId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'messageId' is set
       if (messageId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdStatusGet",
-      new ApiException(400, "Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdStatusGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdStatusGet",
+      new ApiException(400, "Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdStatusGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Communication/PrivateMessages/{MessageId}/Status".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
+  String path = "/Api/Communication/PrivateMessages/{MessageId}/Status".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -260,19 +260,19 @@ public class CommunicationApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Action-PrivateMessages-Query&#x60;**, **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param messageId 
   */
-  public void apiV2CommunicationPrivateMessagesByMessageIdStatusGet (UUID messageId, final Response.Listener<PrivateMessageStatus> responseListener, final Response.ErrorListener errorListener) {
+  public void apiCommunicationPrivateMessagesByMessageIdStatusGet (UUID messageId, final Response.Listener<PrivateMessageStatus> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'messageId' is set
     if (messageId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdStatusGet",
-         new ApiException(400, "Missing the required parameter 'messageId' when calling apiV2CommunicationPrivateMessagesByMessageIdStatusGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdStatusGet",
+         new ApiException(400, "Missing the required parameter 'messageId' when calling apiCommunicationPrivateMessagesByMessageIdStatusGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Communication/PrivateMessages/{MessageId}/Status".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
+    String path = "/Api/Communication/PrivateMessages/{MessageId}/Status".replaceAll("\\{format\\}","json").replaceAll("\\{" + "MessageId" + "\\}", apiInvoker.escapeString(messageId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -327,12 +327,12 @@ public class CommunicationApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**  This will set the &#x60;ReceivedDateTimeUtc&#x60; to the current server time on all messages retrieved  that have not been retrieved in a previous call.
    * @return List<PrivateMessageRecord>
   */
-  public List<PrivateMessageRecord> apiV2CommunicationPrivateMessagesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<PrivateMessageRecord> apiCommunicationPrivateMessagesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
+  String path = "/Api/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -390,13 +390,13 @@ public class CommunicationApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**  This will set the &#x60;ReceivedDateTimeUtc&#x60; to the current server time on all messages retrieved  that have not been retrieved in a previous call.
 
   */
-  public void apiV2CommunicationPrivateMessagesGet (final Response.Listener<List<PrivateMessageRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiCommunicationPrivateMessagesGet (final Response.Listener<List<PrivateMessageRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
+    String path = "/Api/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -452,12 +452,12 @@ public class CommunicationApi {
    * @param request 
    * @return UUID
   */
-  public UUID apiV2CommunicationPrivateMessagesPost (SendPrivateMessageRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public UUID apiCommunicationPrivateMessagesPost (SendPrivateMessageRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = request;
   
 
   // create path and map variables
-  String path = "/Api/v2/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
+  String path = "/Api/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -515,13 +515,13 @@ public class CommunicationApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Action-PrivateMessages-Send&#x60;**, **&#x60;Developer&#x60;**, **&#x60;System&#x60;**  If the backend has a push-channel available to any given device(s) that are currently signed into the app  with the same recipient uid, it will push a toast message to those devices.  The toast message content is defined by the &#x60;ToastTitle&#x60; and &#x60;ToastMessage&#x60; properties.
    * @param request 
   */
-  public void apiV2CommunicationPrivateMessagesPost (SendPrivateMessageRequest request, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
+  public void apiCommunicationPrivateMessagesPost (SendPrivateMessageRequest request, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = request;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
+    String path = "/Api/Communication/PrivateMessages".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -557,6 +557,130 @@ public class CommunicationApi {
           public void onResponse(String localVarResponse) {
             try {
               responseListener.onResponse((UUID) ApiInvoker.deserialize(localVarResponse,  "", UUID.class));
+            } catch (ApiException exception) {
+               errorListener.onErrorResponse(new VolleyError(exception));
+            }
+          }
+      }, new Response.ErrorListener() {
+          @Override
+          public void onErrorResponse(VolleyError error) {
+            errorListener.onErrorResponse(error);
+          }
+      });
+    } catch (ApiException ex) {
+      errorListener.onErrorResponse(new VolleyError(ex));
+    }
+  }
+  /**
+  * 
+  *   * Requires authorization   
+   * @return List<PrivateMessageRecord>
+  */
+  public List<PrivateMessageRecord> apiCommunicationPrivateMessagesSentByMeGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+     Object postBody = null;
+  
+
+  // create path and map variables
+  String path = "/Api/Communication/PrivateMessages/:sent-by-me".replaceAll("\\{format\\}","json");
+
+  // query params
+  List<Pair> queryParams = new ArrayList<Pair>();
+      // header params
+      Map<String, String> headerParams = new HashMap<String, String>();
+      // form params
+      Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+      String[] contentTypes = {
+  
+      };
+      String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+      if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+  
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+      } else {
+      // normal form params
+        }
+
+      String[] authNames = new String[] { "Bearer" };
+
+      try {
+        String localVarResponse = apiInvoker.invokeAPI (basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames);
+        if(localVarResponse != null){
+           return (List<PrivateMessageRecord>) ApiInvoker.deserialize(localVarResponse, "array", PrivateMessageRecord.class);
+        } else {
+           return null;
+        }
+      } catch (ApiException ex) {
+         throw ex;
+      } catch (InterruptedException ex) {
+         throw ex;
+      } catch (ExecutionException ex) {
+         if(ex.getCause() instanceof VolleyError) {
+	    VolleyError volleyError = (VolleyError)ex.getCause();
+	    if (volleyError.networkResponse != null) {
+	       throw new ApiException(volleyError.networkResponse.statusCode, volleyError.getMessage());
+	    }
+         }
+         throw ex;
+      } catch (TimeoutException ex) {
+         throw ex;
+      }
+  }
+
+      /**
+   * 
+   *   * Requires authorization   
+
+  */
+  public void apiCommunicationPrivateMessagesSentByMeGet (final Response.Listener<List<PrivateMessageRecord>> responseListener, final Response.ErrorListener errorListener) {
+    Object postBody = null;
+
+  
+
+    // create path and map variables
+    String path = "/Api/Communication/PrivateMessages/:sent-by-me".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> queryParams = new ArrayList<Pair>();
+    // header params
+    Map<String, String> headerParams = new HashMap<String, String>();
+    // form params
+    Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+    String[] contentTypes = {
+      
+    };
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+    if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+      
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+    } else {
+      // normal form params
+          }
+
+      String[] authNames = new String[] { "Bearer" };
+
+    try {
+      apiInvoker.invokeAPI(basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames,
+        new Response.Listener<String>() {
+          @Override
+          public void onResponse(String localVarResponse) {
+            try {
+              responseListener.onResponse((List<PrivateMessageRecord>) ApiInvoker.deserialize(localVarResponse,  "array", PrivateMessageRecord.class));
             } catch (ApiException exception) {
                errorListener.onErrorResponse(new VolleyError(exception));
             }

--- a/app/src/main/java/io/swagger/client/api/DealersApi.java
+++ b/app/src/main/java/io/swagger/client/api/DealersApi.java
@@ -50,18 +50,18 @@ public class DealersApi {
    * @param id id of the requested entity
    * @return DealerRecord
   */
-  public DealerRecord apiV2DealersByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public DealerRecord apiDealersByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2DealersByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2DealersByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiDealersByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiDealersByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Dealers/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Dealers/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class DealersApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2DealersByIdGet (UUID id, final Response.Listener<DealerRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiDealersByIdGet (UUID id, final Response.Listener<DealerRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2DealersByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2DealersByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiDealersByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiDealersByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Dealers/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Dealers/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -186,12 +186,12 @@ public class DealersApi {
   * 
    * @return List<DealerRecord>
   */
-  public List<DealerRecord> apiV2DealersGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<DealerRecord> apiDealersGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Dealers".replaceAll("\\{format\\}","json");
+  String path = "/Api/Dealers".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -249,13 +249,13 @@ public class DealersApi {
    * 
 
   */
-  public void apiV2DealersGet (final Response.Listener<List<DealerRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiDealersGet (final Response.Listener<List<DealerRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Dealers".replaceAll("\\{format\\}","json");
+    String path = "/Api/Dealers".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/EventConferenceDaysApi.java
+++ b/app/src/main/java/io/swagger/client/api/EventConferenceDaysApi.java
@@ -50,18 +50,18 @@ public class EventConferenceDaysApi {
    * @param id id of the requested entity
    * @return EventConferenceDayRecord
   */
-  public EventConferenceDayRecord apiV2EventConferenceDaysByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public EventConferenceDayRecord apiEventConferenceDaysByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceDaysByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceDaysByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceDaysByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceDaysByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceDays/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/EventConferenceDays/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class EventConferenceDaysApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2EventConferenceDaysByIdGet (UUID id, final Response.Listener<EventConferenceDayRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceDaysByIdGet (UUID id, final Response.Listener<EventConferenceDayRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceDaysByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceDaysByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceDaysByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceDaysByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceDays/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/EventConferenceDays/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -186,12 +186,12 @@ public class EventConferenceDaysApi {
   * 
    * @return List<EventConferenceDayRecord>
   */
-  public List<EventConferenceDayRecord> apiV2EventConferenceDaysGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<EventConferenceDayRecord> apiEventConferenceDaysGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceDays".replaceAll("\\{format\\}","json");
+  String path = "/Api/EventConferenceDays".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -249,13 +249,13 @@ public class EventConferenceDaysApi {
    * 
 
   */
-  public void apiV2EventConferenceDaysGet (final Response.Listener<List<EventConferenceDayRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceDaysGet (final Response.Listener<List<EventConferenceDayRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceDays".replaceAll("\\{format\\}","json");
+    String path = "/Api/EventConferenceDays".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/EventConferenceRoomsApi.java
+++ b/app/src/main/java/io/swagger/client/api/EventConferenceRoomsApi.java
@@ -50,18 +50,18 @@ public class EventConferenceRoomsApi {
    * @param id id of the requested entity
    * @return EventConferenceRoomRecord
   */
-  public EventConferenceRoomRecord apiV2EventConferenceRoomsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public EventConferenceRoomRecord apiEventConferenceRoomsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceRoomsByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceRoomsByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceRoomsByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceRoomsByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceRooms/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/EventConferenceRooms/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class EventConferenceRoomsApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2EventConferenceRoomsByIdGet (UUID id, final Response.Listener<EventConferenceRoomRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceRoomsByIdGet (UUID id, final Response.Listener<EventConferenceRoomRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceRoomsByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceRoomsByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceRoomsByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceRoomsByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceRooms/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/EventConferenceRooms/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -186,12 +186,12 @@ public class EventConferenceRoomsApi {
   * 
    * @return List<EventConferenceRoomRecord>
   */
-  public List<EventConferenceRoomRecord> apiV2EventConferenceRoomsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<EventConferenceRoomRecord> apiEventConferenceRoomsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceRooms".replaceAll("\\{format\\}","json");
+  String path = "/Api/EventConferenceRooms".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -249,13 +249,13 @@ public class EventConferenceRoomsApi {
    * 
 
   */
-  public void apiV2EventConferenceRoomsGet (final Response.Listener<List<EventConferenceRoomRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceRoomsGet (final Response.Listener<List<EventConferenceRoomRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceRooms".replaceAll("\\{format\\}","json");
+    String path = "/Api/EventConferenceRooms".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/EventConferenceTracksApi.java
+++ b/app/src/main/java/io/swagger/client/api/EventConferenceTracksApi.java
@@ -50,18 +50,18 @@ public class EventConferenceTracksApi {
    * @param id id of the requested entity
    * @return EventConferenceTrackRecord
   */
-  public EventConferenceTrackRecord apiV2EventConferenceTracksByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public EventConferenceTrackRecord apiEventConferenceTracksByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceTracksByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceTracksByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceTracksByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceTracksByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceTracks/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/EventConferenceTracks/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class EventConferenceTracksApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2EventConferenceTracksByIdGet (UUID id, final Response.Listener<EventConferenceTrackRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceTracksByIdGet (UUID id, final Response.Listener<EventConferenceTrackRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventConferenceTracksByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventConferenceTracksByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventConferenceTracksByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiEventConferenceTracksByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceTracks/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/EventConferenceTracks/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -186,12 +186,12 @@ public class EventConferenceTracksApi {
   * 
    * @return List<EventConferenceTrackRecord>
   */
-  public List<EventConferenceTrackRecord> apiV2EventConferenceTracksGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<EventConferenceTrackRecord> apiEventConferenceTracksGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/EventConferenceTracks".replaceAll("\\{format\\}","json");
+  String path = "/Api/EventConferenceTracks".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -249,13 +249,13 @@ public class EventConferenceTracksApi {
    * 
 
   */
-  public void apiV2EventConferenceTracksGet (final Response.Listener<List<EventConferenceTrackRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventConferenceTracksGet (final Response.Listener<List<EventConferenceTrackRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/EventConferenceTracks".replaceAll("\\{format\\}","json");
+    String path = "/Api/EventConferenceTracks".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/EventFeedbackApi.java
+++ b/app/src/main/java/io/swagger/client/api/EventFeedbackApi.java
@@ -48,12 +48,12 @@ public class EventFeedbackApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**, **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @return List<EventFeedbackRecord>
   */
-  public List<EventFeedbackRecord> apiV2EventFeedbackGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<EventFeedbackRecord> apiEventFeedbackGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/EventFeedback".replaceAll("\\{format\\}","json");
+  String path = "/Api/EventFeedback".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -111,13 +111,13 @@ public class EventFeedbackApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**, **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
 
   */
-  public void apiV2EventFeedbackGet (final Response.Listener<List<EventFeedbackRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventFeedbackGet (final Response.Listener<List<EventFeedbackRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/EventFeedback".replaceAll("\\{format\\}","json");
+    String path = "/Api/EventFeedback".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -173,12 +173,12 @@ public class EventFeedbackApi {
    * @param record 
    * @return void
   */
-  public void apiV2EventFeedbackPost (EventFeedbackRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiEventFeedbackPost (EventFeedbackRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
 
   // create path and map variables
-  String path = "/Api/v2/EventFeedback".replaceAll("\\{format\\}","json");
+  String path = "/Api/EventFeedback".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -236,13 +236,13 @@ public class EventFeedbackApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**, **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param record 
   */
-  public void apiV2EventFeedbackPost (EventFeedbackRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventFeedbackPost (EventFeedbackRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/EventFeedback".replaceAll("\\{format\\}","json");
+    String path = "/Api/EventFeedback".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/EventsApi.java
+++ b/app/src/main/java/io/swagger/client/api/EventsApi.java
@@ -50,18 +50,18 @@ public class EventsApi {
    * @param id id of the requested entity
    * @return EventRecord
   */
-  public EventRecord apiV2EventsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public EventRecord apiEventsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventsByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventsByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventsByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiEventsByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Events/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Events/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class EventsApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2EventsByIdGet (UUID id, final Response.Listener<EventRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventsByIdGet (UUID id, final Response.Listener<EventRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2EventsByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2EventsByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiEventsByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiEventsByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Events/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Events/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -186,12 +186,12 @@ public class EventsApi {
   * 
    * @return List<EventRecord>
   */
-  public List<EventRecord> apiV2EventsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<EventRecord> apiEventsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Events".replaceAll("\\{format\\}","json");
+  String path = "/Api/Events".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -249,13 +249,13 @@ public class EventsApi {
    * 
 
   */
-  public void apiV2EventsGet (final Response.Listener<List<EventRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiEventsGet (final Response.Listener<List<EventRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Events".replaceAll("\\{format\\}","json");
+    String path = "/Api/Events".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/FursuitsApi.java
+++ b/app/src/main/java/io/swagger/client/api/FursuitsApi.java
@@ -61,18 +61,18 @@ public class FursuitsApi {
    * @param id \&quot;Id\&quot; of the fursuit badge
    * @return byte[]
   */
-  public byte[] apiV2FursuitsBadgesByIdImageGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public byte[] apiFursuitsBadgesByIdImageGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2FursuitsBadgesByIdImageGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2FursuitsBadgesByIdImageGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiFursuitsBadgesByIdImageGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiFursuitsBadgesByIdImageGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/Badges/{Id}/Image".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Fursuits/Badges/{Id}/Image".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -130,19 +130,19 @@ public class FursuitsApi {
    * 
    * @param id \&quot;Id\&quot; of the fursuit badge
   */
-  public void apiV2FursuitsBadgesByIdImageGet (UUID id, final Response.Listener<byte[]> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsBadgesByIdImageGet (UUID id, final Response.Listener<byte[]> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2FursuitsBadgesByIdImageGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2FursuitsBadgesByIdImageGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiFursuitsBadgesByIdImageGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiFursuitsBadgesByIdImageGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/Badges/{Id}/Image".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Fursuits/Badges/{Id}/Image".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -197,12 +197,12 @@ public class FursuitsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;FursuitBadgeSystem&#x60;**, **&#x60;System&#x60;**  **Not meant to be consumed by the mobile apps**
    * @return List<FursuitBadgeRecord>
   */
-  public List<FursuitBadgeRecord> apiV2FursuitsBadgesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<FursuitBadgeRecord> apiFursuitsBadgesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/Badges".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/Badges".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -260,13 +260,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;FursuitBadgeSystem&#x60;**, **&#x60;System&#x60;**  **Not meant to be consumed by the mobile apps**
 
   */
-  public void apiV2FursuitsBadgesGet (final Response.Listener<List<FursuitBadgeRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsBadgesGet (final Response.Listener<List<FursuitBadgeRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/Badges".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/Badges".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -322,12 +322,12 @@ public class FursuitsApi {
    * @param registration 
    * @return void
   */
-  public void apiV2FursuitsBadgesRegistrationPost (FursuitBadgeRegistration registration) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiFursuitsBadgesRegistrationPost (FursuitBadgeRegistration registration) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = registration;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/Badges/Registration".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/Badges/Registration".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -385,13 +385,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;FursuitBadgeSystem&#x60;**, **&#x60;System&#x60;**  This is used by the fursuit badge system to push badge information to this backend.  **Not meant to be consumed by the mobile apps**
    * @param registration 
   */
-  public void apiV2FursuitsBadgesRegistrationPost (FursuitBadgeRegistration registration, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsBadgesRegistrationPost (FursuitBadgeRegistration registration, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = registration;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/Badges/Registration".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/Badges/Registration".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -442,12 +442,12 @@ public class FursuitsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @return List<FursuitParticipationInfo>
   */
-  public List<FursuitParticipationInfo> apiV2FursuitsCollectingGameFursuitParticipationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<FursuitParticipationInfo> apiFursuitsCollectingGameFursuitParticipationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticipation".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/FursuitParticipation".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -505,13 +505,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
 
   */
-  public void apiV2FursuitsCollectingGameFursuitParticipationGet (final Response.Listener<List<FursuitParticipationInfo>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameFursuitParticipationGet (final Response.Listener<List<FursuitParticipationInfo>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticipation".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/FursuitParticipation".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -567,12 +567,12 @@ public class FursuitsApi {
    * @param top 
    * @return List<FursuitScoreboardEntry>
   */
-  public List<FursuitScoreboardEntry> apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet (Integer top) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<FursuitScoreboardEntry> apiFursuitsCollectingGameFursuitParticipationScoreboardGet (Integer top) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticipation/Scoreboard".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/FursuitParticipation/Scoreboard".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -631,13 +631,13 @@ public class FursuitsApi {
    * 
    * @param top 
   */
-  public void apiV2FursuitsCollectingGameFursuitParticipationScoreboardGet (Integer top, final Response.Listener<List<FursuitScoreboardEntry>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameFursuitParticipationScoreboardGet (Integer top, final Response.Listener<List<FursuitScoreboardEntry>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticipation/Scoreboard".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/FursuitParticipation/Scoreboard".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -695,18 +695,18 @@ public class FursuitsApi {
    * @param tokenValue 
    * @return void
   */
-  public void apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost (UUID fursuitBadgeId, String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost (UUID fursuitBadgeId, String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValue;
   
       // verify the required parameter 'fursuitBadgeId' is set
       if (fursuitBadgeId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost",
-      new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"));
+      VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost",
+      new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
+  String path = "/Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -764,19 +764,19 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @param fursuitBadgeId    * @param tokenValue 
   */
-  public void apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost (UUID fursuitBadgeId, String tokenValue, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost (UUID fursuitBadgeId, String tokenValue, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValue;
 
   
     // verify the required parameter 'fursuitBadgeId' is set
     if (fursuitBadgeId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost",
-         new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"));
+       VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost",
+         new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenPost"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
+    String path = "/Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -829,18 +829,18 @@ public class FursuitsApi {
    * @param tokenValue 
    * @return ApiSafeResult
   */
-  public ApiSafeResult apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost (UUID fursuitBadgeId, String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public ApiSafeResult apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost (UUID fursuitBadgeId, String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValue;
   
       // verify the required parameter 'fursuitBadgeId' is set
       if (fursuitBadgeId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost",
-      new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"));
+      VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost",
+      new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
+  String path = "/Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -898,19 +898,19 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @param fursuitBadgeId    * @param tokenValue 
   */
-  public void apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost (UUID fursuitBadgeId, String tokenValue, final Response.Listener<ApiSafeResult> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost (UUID fursuitBadgeId, String tokenValue, final Response.Listener<ApiSafeResult> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValue;
 
   
     // verify the required parameter 'fursuitBadgeId' is set
     if (fursuitBadgeId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost",
-         new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiV2FursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"));
+       VolleyError error = new VolleyError("Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost",
+         new ApiException(400, "Missing the required parameter 'fursuitBadgeId' when calling apiFursuitsCollectingGameFursuitParticpationBadgesByFursuitBadgeIdTokenSafePost"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
+    String path = "/Api/Fursuits/CollectingGame/FursuitParticpation/Badges/{FursuitBadgeId}/Token:safe".replaceAll("\\{format\\}","json").replaceAll("\\{" + "FursuitBadgeId" + "\\}", apiInvoker.escapeString(fursuitBadgeId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -966,12 +966,12 @@ public class FursuitsApi {
    * @param tokenValue 
    * @return CollectTokenResponse
   */
-  public CollectTokenResponse apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public CollectTokenResponse apiFursuitsCollectingGamePlayerParticipationCollectTokenPost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValue;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1029,13 +1029,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @param tokenValue 
   */
-  public void apiV2FursuitsCollectingGamePlayerParticipationCollectTokenPost (String tokenValue, final Response.Listener<CollectTokenResponse> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGamePlayerParticipationCollectTokenPost (String tokenValue, final Response.Listener<CollectTokenResponse> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValue;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1091,12 +1091,12 @@ public class FursuitsApi {
    * @param tokenValue 
    * @return ApiSafeResultCollectTokenResponse
   */
-  public ApiSafeResultCollectTokenResponse apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public ApiSafeResultCollectTokenResponse apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValue;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1154,13 +1154,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @param tokenValue 
   */
-  public void apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost (String tokenValue, final Response.Listener<ApiSafeResultCollectTokenResponse> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost (String tokenValue, final Response.Listener<ApiSafeResultCollectTokenResponse> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValue;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectToken:safe".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1215,12 +1215,12 @@ public class FursuitsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @return List<PlayerCollectionEntry>
   */
-  public List<PlayerCollectionEntry> apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<PlayerCollectionEntry> apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1278,13 +1278,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
 
   */
-  public void apiV2FursuitsCollectingGamePlayerParticipationCollectionEntriesGet (final Response.Listener<List<PlayerCollectionEntry>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGamePlayerParticipationCollectionEntriesGet (final Response.Listener<List<PlayerCollectionEntry>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/CollectionEntries".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1339,12 +1339,12 @@ public class FursuitsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
    * @return PlayerParticipationInfo
   */
-  public PlayerParticipationInfo apiV2FursuitsCollectingGamePlayerParticipationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public PlayerParticipationInfo apiFursuitsCollectingGamePlayerParticipationGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/PlayerParticipation".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1402,13 +1402,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Attendee&#x60;**
 
   */
-  public void apiV2FursuitsCollectingGamePlayerParticipationGet (final Response.Listener<PlayerParticipationInfo> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGamePlayerParticipationGet (final Response.Listener<PlayerParticipationInfo> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/PlayerParticipation".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1464,12 +1464,12 @@ public class FursuitsApi {
    * @param top 
    * @return List<PlayerScoreboardEntry>
   */
-  public List<PlayerScoreboardEntry> apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet (Integer top) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<PlayerScoreboardEntry> apiFursuitsCollectingGamePlayerParticipationScoreboardGet (Integer top) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/Scoreboard".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/Scoreboard".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1528,13 +1528,13 @@ public class FursuitsApi {
    * 
    * @param top 
   */
-  public void apiV2FursuitsCollectingGamePlayerParticipationScoreboardGet (Integer top, final Response.Listener<List<PlayerScoreboardEntry>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGamePlayerParticipationScoreboardGet (Integer top, final Response.Listener<List<PlayerScoreboardEntry>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/PlayerParticipation/Scoreboard".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/PlayerParticipation/Scoreboard".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1588,15 +1588,135 @@ public class FursuitsApi {
   /**
   * 
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
+   * @return void
+  */
+  public void apiFursuitsCollectingGameRecalculatePost () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+     Object postBody = null;
+  
+
+  // create path and map variables
+  String path = "/Api/Fursuits/CollectingGame/Recalculate".replaceAll("\\{format\\}","json");
+
+  // query params
+  List<Pair> queryParams = new ArrayList<Pair>();
+      // header params
+      Map<String, String> headerParams = new HashMap<String, String>();
+      // form params
+      Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+      String[] contentTypes = {
+  
+      };
+      String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+      if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+  
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+      } else {
+      // normal form params
+        }
+
+      String[] authNames = new String[] { "Bearer" };
+
+      try {
+        String localVarResponse = apiInvoker.invokeAPI (basePath, path, "POST", queryParams, postBody, headerParams, formParams, contentType, authNames);
+        if(localVarResponse != null){
+           return ;
+        } else {
+           return ;
+        }
+      } catch (ApiException ex) {
+         throw ex;
+      } catch (InterruptedException ex) {
+         throw ex;
+      } catch (ExecutionException ex) {
+         if(ex.getCause() instanceof VolleyError) {
+	    VolleyError volleyError = (VolleyError)ex.getCause();
+	    if (volleyError.networkResponse != null) {
+	       throw new ApiException(volleyError.networkResponse.statusCode, volleyError.getMessage());
+	    }
+         }
+         throw ex;
+      } catch (TimeoutException ex) {
+         throw ex;
+      }
+  }
+
+      /**
+   * 
+   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
+
+  */
+  public void apiFursuitsCollectingGameRecalculatePost (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+    Object postBody = null;
+
+  
+
+    // create path and map variables
+    String path = "/Api/Fursuits/CollectingGame/Recalculate".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> queryParams = new ArrayList<Pair>();
+    // header params
+    Map<String, String> headerParams = new HashMap<String, String>();
+    // form params
+    Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+    String[] contentTypes = {
+      
+    };
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+    if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+      
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+    } else {
+      // normal form params
+          }
+
+      String[] authNames = new String[] { "Bearer" };
+
+    try {
+      apiInvoker.invokeAPI(basePath, path, "POST", queryParams, postBody, headerParams, formParams, contentType, authNames,
+        new Response.Listener<String>() {
+          @Override
+          public void onResponse(String localVarResponse) {
+              responseListener.onResponse(localVarResponse);
+          }
+      }, new Response.ErrorListener() {
+          @Override
+          public void onErrorResponse(VolleyError error) {
+            errorListener.onErrorResponse(error);
+          }
+      });
+    } catch (ApiException ex) {
+      errorListener.onErrorResponse(new VolleyError(ex));
+    }
+  }
+  /**
+  * 
+  *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param tokenValues 
    * @return void
   */
-  public void apiV2FursuitsCollectingGameTokensBatchPost (List<String> tokenValues) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiFursuitsCollectingGameTokensBatchPost (List<String> tokenValues) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValues;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/Tokens/Batch".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/Tokens/Batch".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1654,13 +1774,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param tokenValues 
   */
-  public void apiV2FursuitsCollectingGameTokensBatchPost (List<String> tokenValues, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameTokensBatchPost (List<String> tokenValues, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValues;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/Tokens/Batch".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/Tokens/Batch".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1712,12 +1832,12 @@ public class FursuitsApi {
    * @param tokenValue 
    * @return void
   */
-  public void apiV2FursuitsCollectingGameTokensPost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiFursuitsCollectingGameTokensPost (String tokenValue) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = tokenValue;
   
 
   // create path and map variables
-  String path = "/Api/v2/Fursuits/CollectingGame/Tokens".replaceAll("\\{format\\}","json");
+  String path = "/Api/Fursuits/CollectingGame/Tokens".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1775,13 +1895,13 @@ public class FursuitsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @param tokenValue 
   */
-  public void apiV2FursuitsCollectingGameTokensPost (String tokenValue, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiFursuitsCollectingGameTokensPost (String tokenValue, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = tokenValue;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Fursuits/CollectingGame/Tokens".replaceAll("\\{format\\}","json");
+    String path = "/Api/Fursuits/CollectingGame/Tokens".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/ImagesApi.java
+++ b/app/src/main/java/io/swagger/client/api/ImagesApi.java
@@ -50,18 +50,18 @@ public class ImagesApi {
    * @param id id of the requested entity
    * @return byte[]
   */
-  public byte[] apiV2ImagesByIdContentGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public byte[] apiImagesByIdContentGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdContentGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdContentGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class ImagesApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2ImagesByIdContentGet (UUID id, final Response.Listener<byte[]> responseListener, final Response.ErrorListener errorListener) {
+  public void apiImagesByIdContentGet (UUID id, final Response.Listener<byte[]> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdContentGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdContentGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -188,18 +188,18 @@ public class ImagesApi {
    * @param imageContent 
    * @return void
   */
-  public void apiV2ImagesByIdContentPut (UUID id, String imageContent) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiImagesByIdContentPut (UUID id, String imageContent) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = imageContent;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdContentPut",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdContentPut"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentPut",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentPut"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -257,19 +257,19 @@ public class ImagesApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param id    * @param imageContent 
   */
-  public void apiV2ImagesByIdContentPut (UUID id, String imageContent, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiImagesByIdContentPut (UUID id, String imageContent, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = imageContent;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdContentPut",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdContentPut"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentPut",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentPut"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Images/{Id}/Content".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -316,23 +316,173 @@ public class ImagesApi {
     }
   }
   /**
+  * Retrieve a single image content using hash code (preferred, as it allows caching).
+  * 
+   * @param id id of the requested entity
+   * @param contentHashBase64Encoded Base64 Encoded ContentHashSha1 of the requested entity
+   * @return byte[]
+  */
+  public byte[] apiImagesByIdContentWithHashcontentHashBase64EncodedGet (UUID id, String contentHashBase64Encoded) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+     Object postBody = null;
+  
+      // verify the required parameter 'id' is set
+      if (id == null) {
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet"));
+      }
+  
+      // verify the required parameter 'contentHashBase64Encoded' is set
+      if (contentHashBase64Encoded == null) {
+      VolleyError error = new VolleyError("Missing the required parameter 'contentHashBase64Encoded' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet",
+      new ApiException(400, "Missing the required parameter 'contentHashBase64Encoded' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet"));
+      }
+  
+
+  // create path and map variables
+  String path = "/Api/Images/{Id}/Content/with-hash:{contentHashBase64Encoded}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "contentHashBase64Encoded" + "\\}", apiInvoker.escapeString(contentHashBase64Encoded.toString()));
+
+  // query params
+  List<Pair> queryParams = new ArrayList<Pair>();
+      // header params
+      Map<String, String> headerParams = new HashMap<String, String>();
+      // form params
+      Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+      String[] contentTypes = {
+  
+      };
+      String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+      if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+  
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+      } else {
+      // normal form params
+        }
+
+      String[] authNames = new String[] {  };
+
+      try {
+        String localVarResponse = apiInvoker.invokeAPI (basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames);
+        if(localVarResponse != null){
+           return (byte[]) ApiInvoker.deserialize(localVarResponse, "", byte[].class);
+        } else {
+           return null;
+        }
+      } catch (ApiException ex) {
+         throw ex;
+      } catch (InterruptedException ex) {
+         throw ex;
+      } catch (ExecutionException ex) {
+         if(ex.getCause() instanceof VolleyError) {
+	    VolleyError volleyError = (VolleyError)ex.getCause();
+	    if (volleyError.networkResponse != null) {
+	       throw new ApiException(volleyError.networkResponse.statusCode, volleyError.getMessage());
+	    }
+         }
+         throw ex;
+      } catch (TimeoutException ex) {
+         throw ex;
+      }
+  }
+
+      /**
+   * Retrieve a single image content using hash code (preferred, as it allows caching).
+   * 
+   * @param id id of the requested entity   * @param contentHashBase64Encoded Base64 Encoded ContentHashSha1 of the requested entity
+  */
+  public void apiImagesByIdContentWithHashcontentHashBase64EncodedGet (UUID id, String contentHashBase64Encoded, final Response.Listener<byte[]> responseListener, final Response.ErrorListener errorListener) {
+    Object postBody = null;
+
+  
+    // verify the required parameter 'id' is set
+    if (id == null) {
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet"));
+    }
+    
+    // verify the required parameter 'contentHashBase64Encoded' is set
+    if (contentHashBase64Encoded == null) {
+       VolleyError error = new VolleyError("Missing the required parameter 'contentHashBase64Encoded' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet",
+         new ApiException(400, "Missing the required parameter 'contentHashBase64Encoded' when calling apiImagesByIdContentWithHashcontentHashBase64EncodedGet"));
+    }
+    
+
+    // create path and map variables
+    String path = "/Api/Images/{Id}/Content/with-hash:{contentHashBase64Encoded}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "contentHashBase64Encoded" + "\\}", apiInvoker.escapeString(contentHashBase64Encoded.toString()));
+
+    // query params
+    List<Pair> queryParams = new ArrayList<Pair>();
+    // header params
+    Map<String, String> headerParams = new HashMap<String, String>();
+    // form params
+    Map<String, String> formParams = new HashMap<String, String>();
+
+
+
+    String[] contentTypes = {
+      
+    };
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+
+    if (contentType.startsWith("multipart/form-data")) {
+      // file uploading
+      MultipartEntityBuilder localVarBuilder = MultipartEntityBuilder.create();
+      
+
+      HttpEntity httpEntity = localVarBuilder.build();
+      postBody = httpEntity;
+    } else {
+      // normal form params
+          }
+
+      String[] authNames = new String[] {  };
+
+    try {
+      apiInvoker.invokeAPI(basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames,
+        new Response.Listener<String>() {
+          @Override
+          public void onResponse(String localVarResponse) {
+            try {
+              responseListener.onResponse((byte[]) ApiInvoker.deserialize(localVarResponse,  "", byte[].class));
+            } catch (ApiException exception) {
+               errorListener.onErrorResponse(new VolleyError(exception));
+            }
+          }
+      }, new Response.ErrorListener() {
+          @Override
+          public void onErrorResponse(VolleyError error) {
+            errorListener.onErrorResponse(error);
+          }
+      });
+    } catch (ApiException ex) {
+      errorListener.onErrorResponse(new VolleyError(ex));
+    }
+  }
+  /**
   * Retrieve a single image.
   * 
    * @param id id of the requested entity
    * @return ImageRecord
   */
-  public ImageRecord apiV2ImagesByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public ImageRecord apiImagesByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Images/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Images/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -390,19 +540,19 @@ public class ImagesApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2ImagesByIdGet (UUID id, final Response.Listener<ImageRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiImagesByIdGet (UUID id, final Response.Listener<ImageRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2ImagesByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2ImagesByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiImagesByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiImagesByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Images/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Images/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -457,12 +607,12 @@ public class ImagesApi {
   * 
    * @return List<ImageRecord>
   */
-  public List<ImageRecord> apiV2ImagesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<ImageRecord> apiImagesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Images".replaceAll("\\{format\\}","json");
+  String path = "/Api/Images".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -520,13 +670,13 @@ public class ImagesApi {
    * 
 
   */
-  public void apiV2ImagesGet (final Response.Listener<List<ImageRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiImagesGet (final Response.Listener<List<ImageRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Images".replaceAll("\\{format\\}","json");
+    String path = "/Api/Images".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/KnowledgeEntriesApi.java
+++ b/app/src/main/java/io/swagger/client/api/KnowledgeEntriesApi.java
@@ -50,18 +50,18 @@ public class KnowledgeEntriesApi {
    * @param id 
    * @return void
   */
-  public void apiV2KnowledgeEntriesByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiKnowledgeEntriesByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdDelete",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdDelete",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdDelete"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class KnowledgeEntriesApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param id 
   */
-  public void apiV2KnowledgeEntriesByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeEntriesByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdDelete",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdDelete",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdDelete"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -183,18 +183,18 @@ public class KnowledgeEntriesApi {
    * @param id id of the requested entity
    * @return KnowledgeEntryRecord
   */
-  public KnowledgeEntryRecord apiV2KnowledgeEntriesByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public KnowledgeEntryRecord apiKnowledgeEntriesByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -252,19 +252,19 @@ public class KnowledgeEntriesApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2KnowledgeEntriesByIdGet (UUID id, final Response.Listener<KnowledgeEntryRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeEntriesByIdGet (UUID id, final Response.Listener<KnowledgeEntryRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -321,18 +321,18 @@ public class KnowledgeEntriesApi {
    * @param record 
    * @return void
   */
-  public void apiV2KnowledgeEntriesByIdPut (UUID id, KnowledgeEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiKnowledgeEntriesByIdPut (UUID id, KnowledgeEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdPut",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdPut"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdPut",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdPut"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -390,19 +390,19 @@ public class KnowledgeEntriesApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param id    * @param record 
   */
-  public void apiV2KnowledgeEntriesByIdPut (UUID id, KnowledgeEntryRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeEntriesByIdPut (UUID id, KnowledgeEntryRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdPut",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeEntriesByIdPut"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdPut",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeEntriesByIdPut"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeEntries/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -453,12 +453,12 @@ public class KnowledgeEntriesApi {
   * 
    * @return List<KnowledgeEntryRecord>
   */
-  public List<KnowledgeEntryRecord> apiV2KnowledgeEntriesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<KnowledgeEntryRecord> apiKnowledgeEntriesGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeEntries".replaceAll("\\{format\\}","json");
+  String path = "/Api/KnowledgeEntries".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -516,13 +516,13 @@ public class KnowledgeEntriesApi {
    * 
 
   */
-  public void apiV2KnowledgeEntriesGet (final Response.Listener<List<KnowledgeEntryRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeEntriesGet (final Response.Listener<List<KnowledgeEntryRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeEntries".replaceAll("\\{format\\}","json");
+    String path = "/Api/KnowledgeEntries".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -578,12 +578,12 @@ public class KnowledgeEntriesApi {
    * @param record 
    * @return UUID
   */
-  public UUID apiV2KnowledgeEntriesPost (KnowledgeEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public UUID apiKnowledgeEntriesPost (KnowledgeEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeEntries".replaceAll("\\{format\\}","json");
+  String path = "/Api/KnowledgeEntries".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -641,13 +641,13 @@ public class KnowledgeEntriesApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param record 
   */
-  public void apiV2KnowledgeEntriesPost (KnowledgeEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeEntriesPost (KnowledgeEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeEntries".replaceAll("\\{format\\}","json");
+    String path = "/Api/KnowledgeEntries".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/KnowledgeGroupsApi.java
+++ b/app/src/main/java/io/swagger/client/api/KnowledgeGroupsApi.java
@@ -50,18 +50,18 @@ public class KnowledgeGroupsApi {
    * @param id 
    * @return void
   */
-  public void apiV2KnowledgeGroupsByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiKnowledgeGroupsByIdDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdDelete",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdDelete",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdDelete"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -119,19 +119,19 @@ public class KnowledgeGroupsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param id 
   */
-  public void apiV2KnowledgeGroupsByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeGroupsByIdDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdDelete",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdDelete",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdDelete"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -183,18 +183,18 @@ public class KnowledgeGroupsApi {
    * @param id id of the requested entity
    * @return KnowledgeGroupRecord
   */
-  public KnowledgeGroupRecord apiV2KnowledgeGroupsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public KnowledgeGroupRecord apiKnowledgeGroupsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -252,19 +252,19 @@ public class KnowledgeGroupsApi {
    * 
    * @param id id of the requested entity
   */
-  public void apiV2KnowledgeGroupsByIdGet (UUID id, final Response.Listener<KnowledgeGroupRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeGroupsByIdGet (UUID id, final Response.Listener<KnowledgeGroupRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -321,18 +321,18 @@ public class KnowledgeGroupsApi {
    * @param record 
    * @return void
   */
-  public void apiV2KnowledgeGroupsByIdPut (UUID id, KnowledgeGroupRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiKnowledgeGroupsByIdPut (UUID id, KnowledgeGroupRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdPut",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdPut"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdPut",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdPut"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -390,19 +390,19 @@ public class KnowledgeGroupsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param id    * @param record 
   */
-  public void apiV2KnowledgeGroupsByIdPut (UUID id, KnowledgeGroupRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeGroupsByIdPut (UUID id, KnowledgeGroupRecord record, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdPut",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2KnowledgeGroupsByIdPut"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdPut",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiKnowledgeGroupsByIdPut"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/KnowledgeGroups/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -453,12 +453,12 @@ public class KnowledgeGroupsApi {
   * 
    * @return List<KnowledgeGroupRecord>
   */
-  public List<KnowledgeGroupRecord> apiV2KnowledgeGroupsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<KnowledgeGroupRecord> apiKnowledgeGroupsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeGroups".replaceAll("\\{format\\}","json");
+  String path = "/Api/KnowledgeGroups".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -516,13 +516,13 @@ public class KnowledgeGroupsApi {
    * 
 
   */
-  public void apiV2KnowledgeGroupsGet (final Response.Listener<List<KnowledgeGroupRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeGroupsGet (final Response.Listener<List<KnowledgeGroupRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeGroups".replaceAll("\\{format\\}","json");
+    String path = "/Api/KnowledgeGroups".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -578,12 +578,12 @@ public class KnowledgeGroupsApi {
    * @param record 
    * @return UUID
   */
-  public UUID apiV2KnowledgeGroupsPost (KnowledgeGroupRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public UUID apiKnowledgeGroupsPost (KnowledgeGroupRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
 
   // create path and map variables
-  String path = "/Api/v2/KnowledgeGroups".replaceAll("\\{format\\}","json");
+  String path = "/Api/KnowledgeGroups".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -641,13 +641,13 @@ public class KnowledgeGroupsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;KnowledgeBase-Maintainer&#x60;**, **&#x60;System&#x60;**
    * @param record 
   */
-  public void apiV2KnowledgeGroupsPost (KnowledgeGroupRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
+  public void apiKnowledgeGroupsPost (KnowledgeGroupRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/KnowledgeGroups".replaceAll("\\{format\\}","json");
+    String path = "/Api/KnowledgeGroups".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/MapsApi.java
+++ b/app/src/main/java/io/swagger/client/api/MapsApi.java
@@ -52,24 +52,24 @@ public class MapsApi {
    * @param entryId 
    * @return void
   */
-  public void apiV2MapsByIdEntriesByEntryIdDelete (UUID id, UUID entryId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiMapsByIdEntriesByEntryIdDelete (UUID id, UUID entryId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdDelete",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdDelete",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdDelete"));
       }
   
       // verify the required parameter 'entryId' is set
       if (entryId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdDelete",
-      new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdDelete",
+      new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdDelete"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+  String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -127,25 +127,25 @@ public class MapsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Admin&#x60;**, **&#x60;Developer&#x60;**
    * @param id    * @param entryId 
   */
-  public void apiV2MapsByIdEntriesByEntryIdDelete (UUID id, UUID entryId, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesByEntryIdDelete (UUID id, UUID entryId, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdDelete",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdDelete",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdDelete"));
     }
     
     // verify the required parameter 'entryId' is set
     if (entryId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdDelete",
-         new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdDelete",
+         new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdDelete"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+    String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -198,24 +198,24 @@ public class MapsApi {
    * @param entryId 
    * @return MapEntryRecord
   */
-  public MapEntryRecord apiV2MapsByIdEntriesByEntryIdGet (UUID id, UUID entryId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public MapEntryRecord apiMapsByIdEntriesByEntryIdGet (UUID id, UUID entryId) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdGet"));
       }
   
       // verify the required parameter 'entryId' is set
       if (entryId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdGet",
-      new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdGet",
+      new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+  String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -273,25 +273,25 @@ public class MapsApi {
    * 
    * @param id    * @param entryId 
   */
-  public void apiV2MapsByIdEntriesByEntryIdGet (UUID id, UUID entryId, final Response.Listener<MapEntryRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesByEntryIdGet (UUID id, UUID entryId, final Response.Listener<MapEntryRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdGet"));
     }
     
     // verify the required parameter 'entryId' is set
     if (entryId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdGet",
-         new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdGet",
+         new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+    String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -349,24 +349,24 @@ public class MapsApi {
    * @param record \&quot;Id\&quot; property must match the {EntryId} part of the uri
    * @return UUID
   */
-  public UUID apiV2MapsByIdEntriesByEntryIdPut (UUID id, UUID entryId, MapEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public UUID apiMapsByIdEntriesByEntryIdPut (UUID id, UUID entryId, MapEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdPut",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdPut"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdPut",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdPut"));
       }
   
       // verify the required parameter 'entryId' is set
       if (entryId == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdPut",
-      new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdPut"));
+      VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdPut",
+      new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdPut"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+  String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -424,25 +424,25 @@ public class MapsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Admin&#x60;**, **&#x60;Developer&#x60;**  This both works for updating an existing entry and creating a new entry. The id property of the  model (request body) must match the {EntryId} part of the uri.
    * @param id \&quot;Id\&quot; of the map.   * @param entryId \&quot;Id\&quot; of the entry that gets inserted.   * @param record \&quot;Id\&quot; property must match the {EntryId} part of the uri
   */
-  public void apiV2MapsByIdEntriesByEntryIdPut (UUID id, UUID entryId, MapEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesByEntryIdPut (UUID id, UUID entryId, MapEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdPut",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesByEntryIdPut"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdPut",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesByEntryIdPut"));
     }
     
     // verify the required parameter 'entryId' is set
     if (entryId == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdPut",
-         new ApiException(400, "Missing the required parameter 'entryId' when calling apiV2MapsByIdEntriesByEntryIdPut"));
+       VolleyError error = new VolleyError("Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdPut",
+         new ApiException(400, "Missing the required parameter 'entryId' when calling apiMapsByIdEntriesByEntryIdPut"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
+    String path = "/Api/Maps/{Id}/Entries/{EntryId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString())).replaceAll("\\{" + "EntryId" + "\\}", apiInvoker.escapeString(entryId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -498,18 +498,18 @@ public class MapsApi {
    * @param id 
    * @return void
   */
-  public void apiV2MapsByIdEntriesDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiMapsByIdEntriesDelete (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesDelete",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesDelete"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesDelete",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesDelete"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -567,19 +567,19 @@ public class MapsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Admin&#x60;**, **&#x60;Developer&#x60;**
    * @param id 
   */
-  public void apiV2MapsByIdEntriesDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesDelete (UUID id, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesDelete",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesDelete"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesDelete",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesDelete"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -631,18 +631,18 @@ public class MapsApi {
    * @param id 
    * @return List<MapEntryRecord>
   */
-  public List<MapEntryRecord> apiV2MapsByIdEntriesGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<MapEntryRecord> apiMapsByIdEntriesGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -700,19 +700,19 @@ public class MapsApi {
    * 
    * @param id 
   */
-  public void apiV2MapsByIdEntriesGet (UUID id, final Response.Listener<List<MapEntryRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesGet (UUID id, final Response.Listener<List<MapEntryRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -769,18 +769,18 @@ public class MapsApi {
    * @param record Do not specify the \&quot;Id\&quot; property. It will be auto-assigned and returned in the response.
    * @return UUID
   */
-  public UUID apiV2MapsByIdEntriesPost (UUID id, MapEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public UUID apiMapsByIdEntriesPost (UUID id, MapEntryRecord record) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = record;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesPost",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesPost"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesPost",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesPost"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -838,19 +838,19 @@ public class MapsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Admin&#x60;**, **&#x60;Developer&#x60;**  If you can generate guids client-side, you can also use the PUT variant for both create and update.
    * @param id \&quot;Id\&quot; of the map   * @param record Do not specify the \&quot;Id\&quot; property. It will be auto-assigned and returned in the response.
   */
-  public void apiV2MapsByIdEntriesPost (UUID id, MapEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdEntriesPost (UUID id, MapEntryRecord record, final Response.Listener<UUID> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = record;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdEntriesPost",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdEntriesPost"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdEntriesPost",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdEntriesPost"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Maps/{Id}/Entries".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -906,18 +906,18 @@ public class MapsApi {
    * @param id 
    * @return MapRecord
   */
-  public MapRecord apiV2MapsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public MapRecord apiMapsByIdGet (UUID id) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
       // verify the required parameter 'id' is set
       if (id == null) {
-      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdGet",
-      new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdGet"));
+      VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdGet",
+      new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdGet"));
       }
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+  String path = "/Api/Maps/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -975,19 +975,19 @@ public class MapsApi {
    * 
    * @param id 
   */
-  public void apiV2MapsByIdGet (UUID id, final Response.Listener<MapRecord> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsByIdGet (UUID id, final Response.Listener<MapRecord> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
     // verify the required parameter 'id' is set
     if (id == null) {
-       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiV2MapsByIdGet",
-         new ApiException(400, "Missing the required parameter 'id' when calling apiV2MapsByIdGet"));
+       VolleyError error = new VolleyError("Missing the required parameter 'id' when calling apiMapsByIdGet",
+         new ApiException(400, "Missing the required parameter 'id' when calling apiMapsByIdGet"));
     }
     
 
     // create path and map variables
-    String path = "/Api/v2/Maps/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
+    String path = "/Api/Maps/{Id}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "Id" + "\\}", apiInvoker.escapeString(id.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -1042,12 +1042,12 @@ public class MapsApi {
   * 
    * @return List<MapRecord>
   */
-  public List<MapRecord> apiV2MapsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public List<MapRecord> apiMapsGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Maps".replaceAll("\\{format\\}","json");
+  String path = "/Api/Maps".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -1105,13 +1105,13 @@ public class MapsApi {
    * 
 
   */
-  public void apiV2MapsGet (final Response.Listener<List<MapRecord>> responseListener, final Response.ErrorListener errorListener) {
+  public void apiMapsGet (final Response.Listener<List<MapRecord>> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Maps".replaceAll("\\{format\\}","json");
+    String path = "/Api/Maps".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/PushNotificationsApi.java
+++ b/app/src/main/java/io/swagger/client/api/PushNotificationsApi.java
@@ -53,12 +53,12 @@ public class PushNotificationsApi {
    * @param request 
    * @return void
   */
-  public void apiV2PushNotificationsFcmDeviceRegistrationPost (PostFcmDeviceRegistrationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiPushNotificationsFcmDeviceRegistrationPost (PostFcmDeviceRegistrationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = request;
   
 
   // create path and map variables
-  String path = "/Api/v2/PushNotifications/FcmDeviceRegistration".replaceAll("\\{format\\}","json");
+  String path = "/Api/PushNotifications/FcmDeviceRegistration".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -116,13 +116,13 @@ public class PushNotificationsApi {
    * 
    * @param request 
   */
-  public void apiV2PushNotificationsFcmDeviceRegistrationPost (PostFcmDeviceRegistrationRequest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiPushNotificationsFcmDeviceRegistrationPost (PostFcmDeviceRegistrationRequest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = request;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/PushNotifications/FcmDeviceRegistration".replaceAll("\\{format\\}","json");
+    String path = "/Api/PushNotifications/FcmDeviceRegistration".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -174,12 +174,12 @@ public class PushNotificationsApi {
    * @param since 
    * @return PushNotificationChannelStatistics
   */
-  public PushNotificationChannelStatistics apiV2PushNotificationsStatisticsGet (Date since) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public PushNotificationChannelStatistics apiPushNotificationsStatisticsGet (Date since) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/PushNotifications/Statistics".replaceAll("\\{format\\}","json");
+  String path = "/Api/PushNotifications/Statistics".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -238,13 +238,13 @@ public class PushNotificationsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**
    * @param since 
   */
-  public void apiV2PushNotificationsStatisticsGet (Date since, final Response.Listener<PushNotificationChannelStatistics> responseListener, final Response.ErrorListener errorListener) {
+  public void apiPushNotificationsStatisticsGet (Date since, final Response.Listener<PushNotificationChannelStatistics> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/PushNotifications/Statistics".replaceAll("\\{format\\}","json");
+    String path = "/Api/PushNotifications/Statistics".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -300,12 +300,12 @@ public class PushNotificationsApi {
   *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
    * @return void
   */
-  public void apiV2PushNotificationsSyncRequestPost () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiPushNotificationsSyncRequestPost () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/PushNotifications/SyncRequest".replaceAll("\\{format\\}","json");
+  String path = "/Api/PushNotifications/SyncRequest".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -363,13 +363,13 @@ public class PushNotificationsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**, **&#x60;System&#x60;**
 
   */
-  public void apiV2PushNotificationsSyncRequestPost (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiPushNotificationsSyncRequestPost (final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/PushNotifications/SyncRequest".replaceAll("\\{format\\}","json");
+    String path = "/Api/PushNotifications/SyncRequest".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -421,12 +421,12 @@ public class PushNotificationsApi {
    * @param request 
    * @return void
   */
-  public void apiV2PushNotificationsWnsChannelRegistrationPost (PostWnsChannelRegistrationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiPushNotificationsWnsChannelRegistrationPost (PostWnsChannelRegistrationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = request;
   
 
   // create path and map variables
-  String path = "/Api/v2/PushNotifications/WnsChannelRegistration".replaceAll("\\{format\\}","json");
+  String path = "/Api/PushNotifications/WnsChannelRegistration".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -484,13 +484,13 @@ public class PushNotificationsApi {
    * 
    * @param request 
   */
-  public void apiV2PushNotificationsWnsChannelRegistrationPost (PostWnsChannelRegistrationRequest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiPushNotificationsWnsChannelRegistrationPost (PostWnsChannelRegistrationRequest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = request;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/PushNotifications/WnsChannelRegistration".replaceAll("\\{format\\}","json");
+    String path = "/Api/PushNotifications/WnsChannelRegistration".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -542,12 +542,12 @@ public class PushNotificationsApi {
    * @param request 
    * @return void
   */
-  public void apiV2PushNotificationsWnsToastPost (ToastTest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public void apiPushNotificationsWnsToastPost (ToastTest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = request;
   
 
   // create path and map variables
-  String path = "/Api/v2/PushNotifications/WnsToast".replaceAll("\\{format\\}","json");
+  String path = "/Api/PushNotifications/WnsToast".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -605,13 +605,13 @@ public class PushNotificationsApi {
    *   * Requires authorization     * Requires any of the following roles: **&#x60;Developer&#x60;**
    * @param request 
   */
-  public void apiV2PushNotificationsWnsToastPost (ToastTest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
+  public void apiPushNotificationsWnsToastPost (ToastTest request, final Response.Listener<String> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = request;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/PushNotifications/WnsToast".replaceAll("\\{format\\}","json");
+    String path = "/Api/PushNotifications/WnsToast".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/SyncApi.java
+++ b/app/src/main/java/io/swagger/client/api/SyncApi.java
@@ -50,12 +50,12 @@ public class SyncApi {
    * @param since 
    * @return AggregatedDeltaResponse
   */
-  public AggregatedDeltaResponse apiV2SyncGet (Date since) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public AggregatedDeltaResponse apiSyncGet (Date since) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Sync".replaceAll("\\{format\\}","json");
+  String path = "/Api/Sync".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -114,13 +114,13 @@ public class SyncApi {
    * 
    * @param since 
   */
-  public void apiV2SyncGet (Date since, final Response.Listener<AggregatedDeltaResponse> responseListener, final Response.ErrorListener errorListener) {
+  public void apiSyncGet (Date since, final Response.Listener<AggregatedDeltaResponse> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Sync".replaceAll("\\{format\\}","json");
+    String path = "/Api/Sync".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/api/TokensApi.java
+++ b/app/src/main/java/io/swagger/client/api/TokensApi.java
@@ -50,12 +50,12 @@ public class TokensApi {
    * @param request 
    * @return AuthenticationResponse
   */
-  public AuthenticationResponse apiV2TokensRegSysPost (RegSysAuthenticationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public AuthenticationResponse apiTokensRegSysPost (RegSysAuthenticationRequest request) throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = request;
   
 
   // create path and map variables
-  String path = "/Api/v2/Tokens/RegSys".replaceAll("\\{format\\}","json");
+  String path = "/Api/Tokens/RegSys".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -113,13 +113,13 @@ public class TokensApi {
    * 
    * @param request 
   */
-  public void apiV2TokensRegSysPost (RegSysAuthenticationRequest request, final Response.Listener<AuthenticationResponse> responseListener, final Response.ErrorListener errorListener) {
+  public void apiTokensRegSysPost (RegSysAuthenticationRequest request, final Response.Listener<AuthenticationResponse> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = request;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Tokens/RegSys".replaceAll("\\{format\\}","json");
+    String path = "/Api/Tokens/RegSys".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -174,12 +174,12 @@ public class TokensApi {
   *   * Requires authorization   
    * @return AuthenticationResponse
   */
-  public AuthenticationResponse apiV2TokensWhoAmIGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
+  public AuthenticationResponse apiTokensWhoAmIGet () throws TimeoutException, ExecutionException, InterruptedException, ApiException {
      Object postBody = null;
   
 
   // create path and map variables
-  String path = "/Api/v2/Tokens/WhoAmI".replaceAll("\\{format\\}","json");
+  String path = "/Api/Tokens/WhoAmI".replaceAll("\\{format\\}","json");
 
   // query params
   List<Pair> queryParams = new ArrayList<Pair>();
@@ -237,13 +237,13 @@ public class TokensApi {
    *   * Requires authorization   
 
   */
-  public void apiV2TokensWhoAmIGet (final Response.Listener<AuthenticationResponse> responseListener, final Response.ErrorListener errorListener) {
+  public void apiTokensWhoAmIGet (final Response.Listener<AuthenticationResponse> responseListener, final Response.ErrorListener errorListener) {
     Object postBody = null;
 
   
 
     // create path and map variables
-    String path = "/Api/v2/Tokens/WhoAmI".replaceAll("\\{format\\}","json");
+    String path = "/Api/Tokens/WhoAmI".replaceAll("\\{format\\}","json");
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/app/src/main/java/io/swagger/client/model/AggregatedDeltaResponse.java
+++ b/app/src/main/java/io/swagger/client/model/AggregatedDeltaResponse.java
@@ -19,6 +19,8 @@ import com.google.gson.annotations.SerializedName;
 @ApiModel(description = "")
 public class AggregatedDeltaResponse  {
   
+  @SerializedName("ConventionIdentifier")
+  private String conventionIdentifier = null;
   @SerializedName("Since")
   private Date since = null;
   @SerializedName("CurrentDateTimeUtc")
@@ -43,6 +45,16 @@ public class AggregatedDeltaResponse  {
   private DeltaResponseAnnouncementRecord announcements = null;
   @SerializedName("Maps")
   private DeltaResponseMapRecord maps = null;
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public String getConventionIdentifier() {
+    return conventionIdentifier;
+  }
+  public void setConventionIdentifier(String conventionIdentifier) {
+    this.conventionIdentifier = conventionIdentifier;
+  }
 
   /**
    **/
@@ -174,7 +186,8 @@ public class AggregatedDeltaResponse  {
       return false;
     }
     AggregatedDeltaResponse aggregatedDeltaResponse = (AggregatedDeltaResponse) o;
-    return (since == null ? aggregatedDeltaResponse.since == null : since.equals(aggregatedDeltaResponse.since)) &&
+    return (conventionIdentifier == null ? aggregatedDeltaResponse.conventionIdentifier == null : conventionIdentifier.equals(aggregatedDeltaResponse.conventionIdentifier)) &&
+        (since == null ? aggregatedDeltaResponse.since == null : since.equals(aggregatedDeltaResponse.since)) &&
         (currentDateTimeUtc == null ? aggregatedDeltaResponse.currentDateTimeUtc == null : currentDateTimeUtc.equals(aggregatedDeltaResponse.currentDateTimeUtc)) &&
         (events == null ? aggregatedDeltaResponse.events == null : events.equals(aggregatedDeltaResponse.events)) &&
         (eventConferenceDays == null ? aggregatedDeltaResponse.eventConferenceDays == null : eventConferenceDays.equals(aggregatedDeltaResponse.eventConferenceDays)) &&
@@ -191,6 +204,7 @@ public class AggregatedDeltaResponse  {
   @Override 
   public int hashCode() {
     int result = 17;
+    result = 31 * result + (conventionIdentifier == null ? 0: conventionIdentifier.hashCode());
     result = 31 * result + (since == null ? 0: since.hashCode());
     result = 31 * result + (currentDateTimeUtc == null ? 0: currentDateTimeUtc.hashCode());
     result = 31 * result + (events == null ? 0: events.hashCode());
@@ -211,6 +225,7 @@ public class AggregatedDeltaResponse  {
     StringBuilder sb = new StringBuilder();
     sb.append("class AggregatedDeltaResponse {\n");
     
+    sb.append("  conventionIdentifier: ").append(conventionIdentifier).append("\n");
     sb.append("  since: ").append(since).append("\n");
     sb.append("  currentDateTimeUtc: ").append(currentDateTimeUtc).append("\n");
     sb.append("  events: ").append(events).append("\n");

--- a/app/src/main/java/io/swagger/client/model/AnnouncementRecord.java
+++ b/app/src/main/java/io/swagger/client/model/AnnouncementRecord.java
@@ -31,7 +31,7 @@ public class AnnouncementRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -41,7 +41,7 @@ public class AnnouncementRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -51,7 +51,7 @@ public class AnnouncementRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getValidFromDateTimeUtc() {
     return validFromDateTimeUtc;
   }
@@ -61,7 +61,7 @@ public class AnnouncementRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getValidUntilDateTimeUtc() {
     return validUntilDateTimeUtc;
   }

--- a/app/src/main/java/io/swagger/client/model/ApiSafeResult.java
+++ b/app/src/main/java/io/swagger/client/model/ApiSafeResult.java
@@ -4,7 +4,6 @@ import io.swagger.client.model.ApiErrorResult;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -17,7 +16,6 @@ public class ApiSafeResult  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Boolean getIsSuccessful() {
     return isSuccessful;

--- a/app/src/main/java/io/swagger/client/model/ApiSafeResultCollectTokenResponse.java
+++ b/app/src/main/java/io/swagger/client/model/ApiSafeResultCollectTokenResponse.java
@@ -5,7 +5,6 @@ import io.swagger.client.model.CollectTokenResponse;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -20,7 +19,6 @@ public class ApiSafeResultCollectTokenResponse  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Boolean getIsSuccessful() {
     return isSuccessful;

--- a/app/src/main/java/io/swagger/client/model/CollectTokenResponse.java
+++ b/app/src/main/java/io/swagger/client/model/CollectTokenResponse.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -33,7 +32,6 @@ public class CollectTokenResponse  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Integer getFursuitCollectionCount() {
     return fursuitCollectionCount;

--- a/app/src/main/java/io/swagger/client/model/DealerRecord.java
+++ b/app/src/main/java/io/swagger/client/model/DealerRecord.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 /**
@@ -61,7 +60,7 @@ public class DealerRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -71,7 +70,7 @@ public class DealerRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -82,8 +81,7 @@ public class DealerRecord  {
   /**
    * Registration number (as on badge) of the attendee that acts on behalf/represents this dealer.
    **/
-  @Nullable
-  @ApiModelProperty(value = "Registration number (as on badge) of the attendee that acts on behalf/represents this dealer.")
+  @ApiModelProperty(required = true, value = "Registration number (as on badge) of the attendee that acts on behalf/represents this dealer.")
   public Integer getRegistrationNumber() {
     return registrationNumber;
   }
@@ -161,7 +159,6 @@ public class DealerRecord  {
    * **(pba)** Link fragments to external website(s) of the dealer.
    **/
   @ApiModelProperty(required = true, value = "**(pba)** Link fragments to external website(s) of the dealer.")
-  @Nullable
   public List<LinkFragment> getLinks() {
     return links;
   }
@@ -194,7 +191,6 @@ public class DealerRecord  {
   /**
    * Flag indicating whether the dealer is present at the dealers den on thursday.
    **/
-  @Nullable
   @ApiModelProperty(value = "Flag indicating whether the dealer is present at the dealers den on thursday.")
   public Boolean getAttendsOnThursday() {
     return attendsOnThursday;
@@ -206,7 +202,6 @@ public class DealerRecord  {
   /**
    * Flag indicating whether the dealer is present at the dealers den on friday.
    **/
-  @Nullable
   @ApiModelProperty(value = "Flag indicating whether the dealer is present at the dealers den on friday.")
   public Boolean getAttendsOnFriday() {
     return attendsOnFriday;
@@ -218,7 +213,6 @@ public class DealerRecord  {
   /**
    * Flag indicating whether the dealer is present at the dealers den on saturday.
    **/
-  @Nullable
   @ApiModelProperty(value = "Flag indicating whether the dealer is present at the dealers den on saturday.")
   public Boolean getAttendsOnSaturday() {
     return attendsOnSaturday;
@@ -274,7 +268,6 @@ public class DealerRecord  {
   /**
    * Flag indicating whether the dealer is located at the after dark dealers den.
    **/
-  @Nullable
   @ApiModelProperty(value = "Flag indicating whether the dealer is located at the after dark dealers den.")
   public Boolean getIsAfterDark() {
     return isAfterDark;
@@ -287,7 +280,6 @@ public class DealerRecord  {
    * **(pba)** List of standardized categories that apply to the goods/services sold/offered by the dealer.
    **/
   @ApiModelProperty(value = "**(pba)** List of standardized categories that apply to the goods/services sold/offered by the dealer.")
-  @Nullable
   public List<String> getCategories() {
     return categories;
   }

--- a/app/src/main/java/io/swagger/client/model/EventConferenceDayRecord.java
+++ b/app/src/main/java/io/swagger/client/model/EventConferenceDayRecord.java
@@ -21,7 +21,7 @@ public class EventConferenceDayRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -31,7 +31,7 @@ public class EventConferenceDayRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }

--- a/app/src/main/java/io/swagger/client/model/EventConferenceRoomRecord.java
+++ b/app/src/main/java/io/swagger/client/model/EventConferenceRoomRecord.java
@@ -19,7 +19,7 @@ public class EventConferenceRoomRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -29,7 +29,7 @@ public class EventConferenceRoomRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }

--- a/app/src/main/java/io/swagger/client/model/EventConferenceTrackRecord.java
+++ b/app/src/main/java/io/swagger/client/model/EventConferenceTrackRecord.java
@@ -19,7 +19,7 @@ public class EventConferenceTrackRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -29,7 +29,7 @@ public class EventConferenceTrackRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }

--- a/app/src/main/java/io/swagger/client/model/EventFeedbackRecord.java
+++ b/app/src/main/java/io/swagger/client/model/EventFeedbackRecord.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -28,7 +27,7 @@ public class EventFeedbackRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -38,7 +37,7 @@ public class EventFeedbackRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -69,7 +68,6 @@ public class EventFeedbackRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getRating() {
     return rating;
   }
@@ -79,7 +77,6 @@ public class EventFeedbackRecord  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Boolean getForwardToPanelist() {
     return forwardToPanelist;

--- a/app/src/main/java/io/swagger/client/model/EventRecord.java
+++ b/app/src/main/java/io/swagger/client/model/EventRecord.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -55,7 +54,7 @@ public class EventRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -65,7 +64,7 @@ public class EventRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -216,7 +215,6 @@ public class EventRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Boolean getIsDeviatingFromConBook() {
     return isDeviatingFromConBook;
   }
@@ -248,7 +246,6 @@ public class EventRecord  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public List<String> getTags() {
     return tags;

--- a/app/src/main/java/io/swagger/client/model/FursuitBadgeRecord.java
+++ b/app/src/main/java/io/swagger/client/model/FursuitBadgeRecord.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -32,7 +31,7 @@ public class FursuitBadgeRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -42,7 +41,7 @@ public class FursuitBadgeRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -113,7 +112,6 @@ public class FursuitBadgeRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Boolean getIsPublic() {
     return isPublic;
   }

--- a/app/src/main/java/io/swagger/client/model/FursuitBadgeRegistration.java
+++ b/app/src/main/java/io/swagger/client/model/FursuitBadgeRegistration.java
@@ -3,7 +3,6 @@ package io.swagger.client.model;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -29,7 +28,6 @@ public class FursuitBadgeRegistration  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getBadgeNo() {
     return badgeNo;
   }
@@ -40,7 +38,6 @@ public class FursuitBadgeRegistration  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getRegNo() {
     return regNo;
   }
@@ -101,7 +98,6 @@ public class FursuitBadgeRegistration  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getDontPublish() {
     return dontPublish;
   }

--- a/app/src/main/java/io/swagger/client/model/FursuitParticipationInfo.java
+++ b/app/src/main/java/io/swagger/client/model/FursuitParticipationInfo.java
@@ -5,7 +5,6 @@ import io.swagger.client.model.FursuitParticipationRecord;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -31,7 +30,6 @@ public class FursuitParticipationInfo  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Boolean getIsParticipating() {
     return isParticipating;
   }

--- a/app/src/main/java/io/swagger/client/model/FursuitParticipationRecord.java
+++ b/app/src/main/java/io/swagger/client/model/FursuitParticipationRecord.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -25,12 +24,14 @@ public class FursuitParticipationRecord  {
   private Boolean isBanned = null;
   @SerializedName("TokenRegistrationDateTimeUtc")
   private Date tokenRegistrationDateTimeUtc = null;
+  @SerializedName("LastCollectionDateTimeUtc")
+  private Date lastCollectionDateTimeUtc = null;
   @SerializedName("CollectionCount")
   private Integer collectionCount = null;
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -40,7 +41,7 @@ public class FursuitParticipationRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -81,7 +82,6 @@ public class FursuitParticipationRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Boolean getIsBanned() {
     return isBanned;
   }
@@ -102,7 +102,16 @@ public class FursuitParticipationRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
+  public Date getLastCollectionDateTimeUtc() {
+    return lastCollectionDateTimeUtc;
+  }
+  public void setLastCollectionDateTimeUtc(Date lastCollectionDateTimeUtc) {
+    this.lastCollectionDateTimeUtc = lastCollectionDateTimeUtc;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   public Integer getCollectionCount() {
     return collectionCount;
   }
@@ -127,6 +136,7 @@ public class FursuitParticipationRecord  {
         (tokenValue == null ? fursuitParticipationRecord.tokenValue == null : tokenValue.equals(fursuitParticipationRecord.tokenValue)) &&
         (isBanned == null ? fursuitParticipationRecord.isBanned == null : isBanned.equals(fursuitParticipationRecord.isBanned)) &&
         (tokenRegistrationDateTimeUtc == null ? fursuitParticipationRecord.tokenRegistrationDateTimeUtc == null : tokenRegistrationDateTimeUtc.equals(fursuitParticipationRecord.tokenRegistrationDateTimeUtc)) &&
+        (lastCollectionDateTimeUtc == null ? fursuitParticipationRecord.lastCollectionDateTimeUtc == null : lastCollectionDateTimeUtc.equals(fursuitParticipationRecord.lastCollectionDateTimeUtc)) &&
         (collectionCount == null ? fursuitParticipationRecord.collectionCount == null : collectionCount.equals(fursuitParticipationRecord.collectionCount));
   }
 
@@ -140,6 +150,7 @@ public class FursuitParticipationRecord  {
     result = 31 * result + (tokenValue == null ? 0: tokenValue.hashCode());
     result = 31 * result + (isBanned == null ? 0: isBanned.hashCode());
     result = 31 * result + (tokenRegistrationDateTimeUtc == null ? 0: tokenRegistrationDateTimeUtc.hashCode());
+    result = 31 * result + (lastCollectionDateTimeUtc == null ? 0: lastCollectionDateTimeUtc.hashCode());
     result = 31 * result + (collectionCount == null ? 0: collectionCount.hashCode());
     return result;
   }
@@ -156,6 +167,7 @@ public class FursuitParticipationRecord  {
     sb.append("  tokenValue: ").append(tokenValue).append("\n");
     sb.append("  isBanned: ").append(isBanned).append("\n");
     sb.append("  tokenRegistrationDateTimeUtc: ").append(tokenRegistrationDateTimeUtc).append("\n");
+    sb.append("  lastCollectionDateTimeUtc: ").append(lastCollectionDateTimeUtc).append("\n");
     sb.append("  collectionCount: ").append(collectionCount).append("\n");
     sb.append("}\n");
     return sb.toString();

--- a/app/src/main/java/io/swagger/client/model/FursuitScoreboardEntry.java
+++ b/app/src/main/java/io/swagger/client/model/FursuitScoreboardEntry.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -26,7 +25,6 @@ public class FursuitScoreboardEntry  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getCollectionCount() {
     return collectionCount;
   }
@@ -47,7 +45,6 @@ public class FursuitScoreboardEntry  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getRank() {
     return rank;
   }

--- a/app/src/main/java/io/swagger/client/model/ImageRecord.java
+++ b/app/src/main/java/io/swagger/client/model/ImageRecord.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -30,7 +29,7 @@ public class ImageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -40,7 +39,7 @@ public class ImageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -60,8 +59,7 @@ public class ImageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
-  @Nullable
+  @ApiModelProperty(required = true, value = "")
   public Integer getWidth() {
     return width;
   }
@@ -71,8 +69,7 @@ public class ImageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
-  @Nullable
+  @ApiModelProperty(required = true, value = "")
   public Integer getHeight() {
     return height;
   }
@@ -82,7 +79,7 @@ public class ImageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Long getSizeInBytes() {
     return sizeInBytes;
   }

--- a/app/src/main/java/io/swagger/client/model/KnowledgeEntryRecord.java
+++ b/app/src/main/java/io/swagger/client/model/KnowledgeEntryRecord.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -32,7 +31,7 @@ public class KnowledgeEntryRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -42,7 +41,7 @@ public class KnowledgeEntryRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -52,7 +51,7 @@ public class KnowledgeEntryRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getKnowledgeGroupId() {
     return knowledgeGroupId;
   }
@@ -82,8 +81,7 @@ public class KnowledgeEntryRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
-  @Nullable
+  @ApiModelProperty(required = true, value = "")
   public Integer getOrder() {
     return order;
   }
@@ -93,7 +91,6 @@ public class KnowledgeEntryRecord  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public List<LinkFragment> getLinks() {
     return links;
@@ -105,7 +102,6 @@ public class KnowledgeEntryRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public List<UUID> getImageIds() {
     return imageIds;
   }

--- a/app/src/main/java/io/swagger/client/model/KnowledgeGroupRecord.java
+++ b/app/src/main/java/io/swagger/client/model/KnowledgeGroupRecord.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -20,17 +19,15 @@ public class KnowledgeGroupRecord  {
   @SerializedName("Description")
   private String description = null;
   @SerializedName("Order")
-  @Nullable
   private Integer order = null;
   @SerializedName("ShowInHamburgerMenu")
-  @Nullable
   private Boolean showInHamburgerMenu = null;
   @SerializedName("FontAwesomeIconCharacterUnicodeAddress")
   private String fontAwesomeIconCharacterUnicodeAddress = null;
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -40,7 +37,7 @@ public class KnowledgeGroupRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -70,7 +67,7 @@ public class KnowledgeGroupRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Integer getOrder() {
     return order;
   }

--- a/app/src/main/java/io/swagger/client/model/LinkFragment.java
+++ b/app/src/main/java/io/swagger/client/model/LinkFragment.java
@@ -20,7 +20,7 @@ public class LinkFragment  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public FragmentTypeEnum getFragmentType() {
     return fragmentType;
   }

--- a/app/src/main/java/io/swagger/client/model/MapEntryRecord.java
+++ b/app/src/main/java/io/swagger/client/model/MapEntryRecord.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -25,7 +24,7 @@ public class MapEntryRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -37,7 +36,6 @@ public class MapEntryRecord  {
    * \"X\" coordinate of the *center* of a *circular area*, expressed in pixels.
    **/
   @ApiModelProperty(value = "\"X\" coordinate of the *center* of a *circular area*, expressed in pixels.")
-  @Nullable
   public Integer getX() {
     return X;
   }
@@ -49,7 +47,6 @@ public class MapEntryRecord  {
    * \"Y\" coordinate of the *center* of a *circular area*, expressed in pixels.
    **/
   @ApiModelProperty(value = "\"Y\" coordinate of the *center* of a *circular area*, expressed in pixels.")
-  @Nullable
   public Integer getY() {
     return Y;
   }
@@ -61,7 +58,6 @@ public class MapEntryRecord  {
    * \"Radius\" of a *circular area* (the center of which described with X and Y), expressed in pixels.
    **/
   @ApiModelProperty(value = "\"Radius\" of a *circular area* (the center of which described with X and Y), expressed in pixels.")
-  @Nullable
   public Integer getTapRadius() {
     return tapRadius;
   }
@@ -72,7 +68,6 @@ public class MapEntryRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public List<LinkFragment> getLinks() {
     return links;
   }

--- a/app/src/main/java/io/swagger/client/model/MapRecord.java
+++ b/app/src/main/java/io/swagger/client/model/MapRecord.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -28,7 +27,7 @@ public class MapRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -38,7 +37,7 @@ public class MapRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -48,7 +47,7 @@ public class MapRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getImageId() {
     return imageId;
   }
@@ -68,8 +67,7 @@ public class MapRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
-  @Nullable
+  @ApiModelProperty(required = true, value = "")
   public Boolean getIsBrowseable() {
     return isBrowseable;
   }
@@ -80,7 +78,6 @@ public class MapRecord  {
   /**
    **/
   @ApiModelProperty(required = true, value = "")
-  @Nullable
   public List<MapEntryRecord> getEntries() {
     return entries;
   }

--- a/app/src/main/java/io/swagger/client/model/PlatformTagInfo.java
+++ b/app/src/main/java/io/swagger/client/model/PlatformTagInfo.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -30,7 +29,6 @@ public class PlatformTagInfo  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public List<String> getTags() {
     return tags;
   }
@@ -41,7 +39,6 @@ public class PlatformTagInfo  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getDeviceCount() {
     return deviceCount;
   }

--- a/app/src/main/java/io/swagger/client/model/PlayerCollectionEntry.java
+++ b/app/src/main/java/io/swagger/client/model/PlayerCollectionEntry.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -76,7 +75,6 @@ public class PlayerCollectionEntry  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Integer getCollectionCount() {
     return collectionCount;

--- a/app/src/main/java/io/swagger/client/model/PlayerParticipationInfo.java
+++ b/app/src/main/java/io/swagger/client/model/PlayerParticipationInfo.java
@@ -5,12 +5,11 @@ import java.util.*;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
 public class PlayerParticipationInfo  {
-
+  
   @SerializedName("Name")
   private String name = null;
   @SerializedName("IsBanned")
@@ -34,7 +33,6 @@ public class PlayerParticipationInfo  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Boolean getIsBanned() {
     return isBanned;
@@ -45,7 +43,6 @@ public class PlayerParticipationInfo  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Integer getCollectionCount() {
     return collectionCount;
@@ -66,7 +63,6 @@ public class PlayerParticipationInfo  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public List<BadgeInfo> getRecentlyCollected() {
     return recentlyCollected;
@@ -92,7 +88,7 @@ public class PlayerParticipationInfo  {
         (recentlyCollected == null ? playerParticipationInfo.recentlyCollected == null : recentlyCollected.equals(playerParticipationInfo.recentlyCollected));
   }
 
-  @Override
+  @Override 
   public int hashCode() {
     int result = 17;
     result = 31 * result + (name == null ? 0: name.hashCode());
@@ -107,7 +103,7 @@ public class PlayerParticipationInfo  {
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class PlayerParticipationInfo {\n");
-
+    
     sb.append("  name: ").append(name).append("\n");
     sb.append("  isBanned: ").append(isBanned).append("\n");
     sb.append("  collectionCount: ").append(collectionCount).append("\n");

--- a/app/src/main/java/io/swagger/client/model/PlayerScoreboardEntry.java
+++ b/app/src/main/java/io/swagger/client/model/PlayerScoreboardEntry.java
@@ -3,7 +3,6 @@ package io.swagger.client.model;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -18,7 +17,6 @@ public class PlayerScoreboardEntry  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Integer getCollectionCount() {
     return collectionCount;
@@ -39,7 +37,6 @@ public class PlayerScoreboardEntry  {
 
   /**
    **/
-  @Nullable
   @ApiModelProperty(value = "")
   public Integer getRank() {
     return rank;

--- a/app/src/main/java/io/swagger/client/model/PostFcmDeviceRegistrationRequest.java
+++ b/app/src/main/java/io/swagger/client/model/PostFcmDeviceRegistrationRequest.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -28,7 +27,6 @@ public class PostFcmDeviceRegistrationRequest  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public List<String> getTopics() {
     return topics;
   }

--- a/app/src/main/java/io/swagger/client/model/PostWnsChannelRegistrationRequest.java
+++ b/app/src/main/java/io/swagger/client/model/PostWnsChannelRegistrationRequest.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -40,7 +39,6 @@ public class PostWnsChannelRegistrationRequest  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public List<String> getTopics() {
     return topics;
   }

--- a/app/src/main/java/io/swagger/client/model/PrivateMessageRecord.java
+++ b/app/src/main/java/io/swagger/client/model/PrivateMessageRecord.java
@@ -16,6 +16,8 @@ public class PrivateMessageRecord  {
   private UUID id = null;
   @SerializedName("RecipientUid")
   private String recipientUid = null;
+  @SerializedName("SenderUid")
+  private String senderUid = null;
   @SerializedName("CreatedDateTimeUtc")
   private Date createdDateTimeUtc = null;
   @SerializedName("ReceivedDateTimeUtc")
@@ -31,7 +33,7 @@ public class PrivateMessageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public Date getLastChangeDateTimeUtc() {
     return lastChangeDateTimeUtc;
   }
@@ -41,7 +43,7 @@ public class PrivateMessageRecord  {
 
   /**
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   public UUID getId() {
     return id;
   }
@@ -62,6 +64,16 @@ public class PrivateMessageRecord  {
   /**
    **/
   @ApiModelProperty(value = "")
+  public String getSenderUid() {
+    return senderUid;
+  }
+  public void setSenderUid(String senderUid) {
+    this.senderUid = senderUid;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
   public Date getCreatedDateTimeUtc() {
     return createdDateTimeUtc;
   }
@@ -132,6 +144,7 @@ public class PrivateMessageRecord  {
     return (lastChangeDateTimeUtc == null ? privateMessageRecord.lastChangeDateTimeUtc == null : lastChangeDateTimeUtc.equals(privateMessageRecord.lastChangeDateTimeUtc)) &&
         (id == null ? privateMessageRecord.id == null : id.equals(privateMessageRecord.id)) &&
         (recipientUid == null ? privateMessageRecord.recipientUid == null : recipientUid.equals(privateMessageRecord.recipientUid)) &&
+        (senderUid == null ? privateMessageRecord.senderUid == null : senderUid.equals(privateMessageRecord.senderUid)) &&
         (createdDateTimeUtc == null ? privateMessageRecord.createdDateTimeUtc == null : createdDateTimeUtc.equals(privateMessageRecord.createdDateTimeUtc)) &&
         (receivedDateTimeUtc == null ? privateMessageRecord.receivedDateTimeUtc == null : receivedDateTimeUtc.equals(privateMessageRecord.receivedDateTimeUtc)) &&
         (readDateTimeUtc == null ? privateMessageRecord.readDateTimeUtc == null : readDateTimeUtc.equals(privateMessageRecord.readDateTimeUtc)) &&
@@ -146,6 +159,7 @@ public class PrivateMessageRecord  {
     result = 31 * result + (lastChangeDateTimeUtc == null ? 0: lastChangeDateTimeUtc.hashCode());
     result = 31 * result + (id == null ? 0: id.hashCode());
     result = 31 * result + (recipientUid == null ? 0: recipientUid.hashCode());
+    result = 31 * result + (senderUid == null ? 0: senderUid.hashCode());
     result = 31 * result + (createdDateTimeUtc == null ? 0: createdDateTimeUtc.hashCode());
     result = 31 * result + (receivedDateTimeUtc == null ? 0: receivedDateTimeUtc.hashCode());
     result = 31 * result + (readDateTimeUtc == null ? 0: readDateTimeUtc.hashCode());
@@ -163,6 +177,7 @@ public class PrivateMessageRecord  {
     sb.append("  lastChangeDateTimeUtc: ").append(lastChangeDateTimeUtc).append("\n");
     sb.append("  id: ").append(id).append("\n");
     sb.append("  recipientUid: ").append(recipientUid).append("\n");
+    sb.append("  senderUid: ").append(senderUid).append("\n");
     sb.append("  createdDateTimeUtc: ").append(createdDateTimeUtc).append("\n");
     sb.append("  receivedDateTimeUtc: ").append(receivedDateTimeUtc).append("\n");
     sb.append("  readDateTimeUtc: ").append(readDateTimeUtc).append("\n");

--- a/app/src/main/java/io/swagger/client/model/PushNotificationChannelStatistics.java
+++ b/app/src/main/java/io/swagger/client/model/PushNotificationChannelStatistics.java
@@ -1,126 +1,116 @@
 package io.swagger.client.model;
 
-import com.google.gson.annotations.SerializedName;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import org.jetbrains.annotations.Nullable;
-
+import io.swagger.client.model.PlatformTagInfo;
+import java.util.*;
 import java.util.Date;
-import java.util.List;
+
+import io.swagger.annotations.*;
+import com.google.gson.annotations.SerializedName;
 
 
 @ApiModel(description = "")
-public class PushNotificationChannelStatistics {
+public class PushNotificationChannelStatistics  {
+  
+  @SerializedName("SinceLastSeenDateTimeUtc")
+  private Date sinceLastSeenDateTimeUtc = null;
+  @SerializedName("NumberOfDevices")
+  private Integer numberOfDevices = null;
+  @SerializedName("NumberOfAuthenticatedDevices")
+  private Integer numberOfAuthenticatedDevices = null;
+  @SerializedName("NumberOfUniqueUserIds")
+  private Integer numberOfUniqueUserIds = null;
+  @SerializedName("PlatformStatistics")
+  private List<PlatformTagInfo> platformStatistics = null;
 
-    @SerializedName("SinceLastSeenDateTimeUtc")
-    private Date sinceLastSeenDateTimeUtc = null;
-    @SerializedName("NumberOfDevices")
-    private Integer numberOfDevices = null;
-    @SerializedName("NumberOfAuthenticatedDevices")
-    private Integer numberOfAuthenticatedDevices = null;
-    @SerializedName("NumberOfUniqueUserIds")
-    private Integer numberOfUniqueUserIds = null;
-    @SerializedName("PlatformStatistics")
-    private List<PlatformTagInfo> platformStatistics = null;
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public Date getSinceLastSeenDateTimeUtc() {
+    return sinceLastSeenDateTimeUtc;
+  }
+  public void setSinceLastSeenDateTimeUtc(Date sinceLastSeenDateTimeUtc) {
+    this.sinceLastSeenDateTimeUtc = sinceLastSeenDateTimeUtc;
+  }
 
-    /**
-     **/
-    @ApiModelProperty(value = "")
-    public Date getSinceLastSeenDateTimeUtc() {
-        return sinceLastSeenDateTimeUtc;
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public Integer getNumberOfDevices() {
+    return numberOfDevices;
+  }
+  public void setNumberOfDevices(Integer numberOfDevices) {
+    this.numberOfDevices = numberOfDevices;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public Integer getNumberOfAuthenticatedDevices() {
+    return numberOfAuthenticatedDevices;
+  }
+  public void setNumberOfAuthenticatedDevices(Integer numberOfAuthenticatedDevices) {
+    this.numberOfAuthenticatedDevices = numberOfAuthenticatedDevices;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public Integer getNumberOfUniqueUserIds() {
+    return numberOfUniqueUserIds;
+  }
+  public void setNumberOfUniqueUserIds(Integer numberOfUniqueUserIds) {
+    this.numberOfUniqueUserIds = numberOfUniqueUserIds;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public List<PlatformTagInfo> getPlatformStatistics() {
+    return platformStatistics;
+  }
+  public void setPlatformStatistics(List<PlatformTagInfo> platformStatistics) {
+    this.platformStatistics = platformStatistics;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-
-    public void setSinceLastSeenDateTimeUtc(Date sinceLastSeenDateTimeUtc) {
-        this.sinceLastSeenDateTimeUtc = sinceLastSeenDateTimeUtc;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
+    PushNotificationChannelStatistics pushNotificationChannelStatistics = (PushNotificationChannelStatistics) o;
+    return (sinceLastSeenDateTimeUtc == null ? pushNotificationChannelStatistics.sinceLastSeenDateTimeUtc == null : sinceLastSeenDateTimeUtc.equals(pushNotificationChannelStatistics.sinceLastSeenDateTimeUtc)) &&
+        (numberOfDevices == null ? pushNotificationChannelStatistics.numberOfDevices == null : numberOfDevices.equals(pushNotificationChannelStatistics.numberOfDevices)) &&
+        (numberOfAuthenticatedDevices == null ? pushNotificationChannelStatistics.numberOfAuthenticatedDevices == null : numberOfAuthenticatedDevices.equals(pushNotificationChannelStatistics.numberOfAuthenticatedDevices)) &&
+        (numberOfUniqueUserIds == null ? pushNotificationChannelStatistics.numberOfUniqueUserIds == null : numberOfUniqueUserIds.equals(pushNotificationChannelStatistics.numberOfUniqueUserIds)) &&
+        (platformStatistics == null ? pushNotificationChannelStatistics.platformStatistics == null : platformStatistics.equals(pushNotificationChannelStatistics.platformStatistics));
+  }
 
-    /**
-     **/
-    @Nullable
-    @ApiModelProperty(value = "")
-    public Integer getNumberOfDevices() {
-        return numberOfDevices;
-    }
+  @Override 
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + (sinceLastSeenDateTimeUtc == null ? 0: sinceLastSeenDateTimeUtc.hashCode());
+    result = 31 * result + (numberOfDevices == null ? 0: numberOfDevices.hashCode());
+    result = 31 * result + (numberOfAuthenticatedDevices == null ? 0: numberOfAuthenticatedDevices.hashCode());
+    result = 31 * result + (numberOfUniqueUserIds == null ? 0: numberOfUniqueUserIds.hashCode());
+    result = 31 * result + (platformStatistics == null ? 0: platformStatistics.hashCode());
+    return result;
+  }
 
-    public void setNumberOfDevices(Integer numberOfDevices) {
-        this.numberOfDevices = numberOfDevices;
-    }
-
-    /**
-     **/
-    @Nullable
-    @ApiModelProperty(value = "")
-    public Integer getNumberOfAuthenticatedDevices() {
-        return numberOfAuthenticatedDevices;
-    }
-
-    public void setNumberOfAuthenticatedDevices(Integer numberOfAuthenticatedDevices) {
-        this.numberOfAuthenticatedDevices = numberOfAuthenticatedDevices;
-    }
-
-    /**
-     **/
-    @Nullable
-    @ApiModelProperty(value = "")
-    public Integer getNumberOfUniqueUserIds() {
-        return numberOfUniqueUserIds;
-    }
-
-    public void setNumberOfUniqueUserIds(Integer numberOfUniqueUserIds) {
-        this.numberOfUniqueUserIds = numberOfUniqueUserIds;
-    }
-
-    /**
-     **/
-    @ApiModelProperty(value = "")
-    @Nullable
-    public List<PlatformTagInfo> getPlatformStatistics() {
-        return platformStatistics;
-    }
-
-    public void setPlatformStatistics(List<PlatformTagInfo> platformStatistics) {
-        this.platformStatistics = platformStatistics;
-    }
-
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        PushNotificationChannelStatistics pushNotificationChannelStatistics = (PushNotificationChannelStatistics) o;
-        return (sinceLastSeenDateTimeUtc == null ? pushNotificationChannelStatistics.sinceLastSeenDateTimeUtc == null : sinceLastSeenDateTimeUtc.equals(pushNotificationChannelStatistics.sinceLastSeenDateTimeUtc)) &&
-                (numberOfDevices == null ? pushNotificationChannelStatistics.numberOfDevices == null : numberOfDevices.equals(pushNotificationChannelStatistics.numberOfDevices)) &&
-                (numberOfAuthenticatedDevices == null ? pushNotificationChannelStatistics.numberOfAuthenticatedDevices == null : numberOfAuthenticatedDevices.equals(pushNotificationChannelStatistics.numberOfAuthenticatedDevices)) &&
-                (numberOfUniqueUserIds == null ? pushNotificationChannelStatistics.numberOfUniqueUserIds == null : numberOfUniqueUserIds.equals(pushNotificationChannelStatistics.numberOfUniqueUserIds)) &&
-                (platformStatistics == null ? pushNotificationChannelStatistics.platformStatistics == null : platformStatistics.equals(pushNotificationChannelStatistics.platformStatistics));
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 17;
-        result = 31 * result + (sinceLastSeenDateTimeUtc == null ? 0 : sinceLastSeenDateTimeUtc.hashCode());
-        result = 31 * result + (numberOfDevices == null ? 0 : numberOfDevices.hashCode());
-        result = 31 * result + (numberOfAuthenticatedDevices == null ? 0 : numberOfAuthenticatedDevices.hashCode());
-        result = 31 * result + (numberOfUniqueUserIds == null ? 0 : numberOfUniqueUserIds.hashCode());
-        result = 31 * result + (platformStatistics == null ? 0 : platformStatistics.hashCode());
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class PushNotificationChannelStatistics {\n");
-
-        sb.append("  sinceLastSeenDateTimeUtc: ").append(sinceLastSeenDateTimeUtc).append("\n");
-        sb.append("  numberOfDevices: ").append(numberOfDevices).append("\n");
-        sb.append("  numberOfAuthenticatedDevices: ").append(numberOfAuthenticatedDevices).append("\n");
-        sb.append("  numberOfUniqueUserIds: ").append(numberOfUniqueUserIds).append("\n");
-        sb.append("  platformStatistics: ").append(platformStatistics).append("\n");
-        sb.append("}\n");
-        return sb.toString();
-    }
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PushNotificationChannelStatistics {\n");
+    
+    sb.append("  sinceLastSeenDateTimeUtc: ").append(sinceLastSeenDateTimeUtc).append("\n");
+    sb.append("  numberOfDevices: ").append(numberOfDevices).append("\n");
+    sb.append("  numberOfAuthenticatedDevices: ").append(numberOfAuthenticatedDevices).append("\n");
+    sb.append("  numberOfUniqueUserIds: ").append(numberOfUniqueUserIds).append("\n");
+    sb.append("  platformStatistics: ").append(platformStatistics).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
 }

--- a/app/src/main/java/io/swagger/client/model/RegSysAuthenticationRequest.java
+++ b/app/src/main/java/io/swagger/client/model/RegSysAuthenticationRequest.java
@@ -3,7 +3,6 @@ package io.swagger.client.model;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
 
 
 @ApiModel(description = "")
@@ -21,7 +20,6 @@ public class RegSysAuthenticationRequest  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @Nullable
   public Integer getRegNo() {
     return regNo;
   }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/broadcast/LoginReceiver.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/broadcast/LoginReceiver.kt
@@ -39,7 +39,7 @@ class LoginReceiver : BroadcastReceiver(), AnkoLogger {
         info { "Attempting login for $username with reg number $regNumber, $username, $password" }
 
         task {
-            apiService.tokens.apiV2TokensRegSysPost(RegSysAuthenticationRequest().apply {
+            apiService.tokens.apiTokensRegSysPost(RegSysAuthenticationRequest().apply {
                 this.regNo = regNumber.toInt()
                 this.username = username
                 this.password = password

--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
@@ -4,6 +4,7 @@ import android.app.IntentService
 import android.content.Context
 import android.content.Intent
 import android.support.v4.content.LocalBroadcastManager
+import org.eurofurence.connavigator.BuildConfig
 import org.eurofurence.connavigator.broadcast.EventFavoriteBroadcast
 import org.eurofurence.connavigator.net.imageService
 import org.eurofurence.connavigator.pref.DebugPreferences
@@ -65,6 +66,10 @@ class UpdateIntentService : IntentService("UpdateIntentService"), HasDb, AnkoLog
             val sync = apiService.sync.apiSyncGet(date)
 
             info { sync }
+
+            if (sync.conventionIdentifier != BuildConfig.CONVENTION_IDENTIFIER) {
+                throw Exception("Convention Identifier mismatch\n\nExpected: ${BuildConfig.CONVENTION_IDENTIFIER}\nReceived: ${sync.conventionIdentifier}")
+            }
 
             val shift = DebugPreferences.debugDates
             val shiftOffset = DebugPreferences.eventDateOffset

--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
@@ -136,6 +136,12 @@ class UpdateIntentService : IntentService("UpdateIntentService"), HasDb, AnkoLog
             } to UpdateComplete(true, date, null)
         } catchAlternative { ex: Throwable ->
             // Make the fail response message, transfer exception
+            if (showToastOnCompletion) {
+                runOnUiThread {
+                    longToast("Failed to update: ${ex.message}")
+                }
+            }
+
             error("Completed update with error", ex)
             UPDATE_COMPLETE.toIntent {
                 booleans["success"] = false

--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/UpdateIntentService.kt
@@ -62,7 +62,7 @@ class UpdateIntentService : IntentService("UpdateIntentService"), HasDb, AnkoLog
             info { "Retrieving sync since $date" }
 
             // Get sync from server
-            val sync = apiService.sync.apiV2SyncGet(date)
+            val sync = apiService.sync.apiSyncGet(date)
 
             info { sync }
 
@@ -72,7 +72,7 @@ class UpdateIntentService : IntentService("UpdateIntentService"), HasDb, AnkoLog
             if (shift) {
                 debug { "Changing dates instead of updating" }
                 // Get all dates explicitly
-                val base = apiService.days.apiV2EventConferenceDaysGet()
+                val base = apiService.days.apiEventConferenceDaysGet()
 
                 // Shift by offset
                 val currentDate = DateTime.now()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/gcm/InstanceIdService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/gcm/InstanceIdService.kt
@@ -33,15 +33,15 @@ class InstanceIdService : FirebaseInstanceIdService(), AnkoLogger {
 
         task {
             var sendTopics= listOf(
-                    "live",
                     "android",
-                    "version-${BuildConfig.VERSION_NAME}"
+                    "version-${BuildConfig.VERSION_NAME}",
+                    "cid-${BuildConfig.CONVENTION_IDENTIFIER}"
             )
 
-            if(BuildConfig.DEBUG) sendTopics += "test"
+            if(BuildConfig.DEBUG) sendTopics += "debug"
 
             info { "Making network request" }
-            apiService.pushNotifications.apiV2PushNotificationsFcmDeviceRegistrationPost(
+            apiService.pushNotifications.apiPushNotificationsFcmDeviceRegistrationPost(
                     PostFcmDeviceRegistrationRequest().apply {
                         deviceId = token
                         topics = sendTopics

--- a/app/src/main/kotlin/org/eurofurence/connavigator/gcm/PushListenerService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/gcm/PushListenerService.kt
@@ -22,14 +22,9 @@ class PushListenerService : FirebaseMessagingService(), AnkoLogger {
         val messaging = FirebaseMessaging.getInstance()
 
         var topics = listOf(
-                "live-all",
-                "live-android"
+                "${BuildConfig.CONVENTION_IDENTIFIER}",
+                "${BuildConfig.CONVENTION_IDENTIFIER}-android"
         )
-
-        if (BuildConfig.DEBUG) {
-            topics += listOf("test-all", "test-android")
-        }
-
         topics.forEach { messaging.subscribeToTopic(it) }
 
         info { "Push token: " + FirebaseInstanceId.getInstance().token }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/pref/RemotePreferences.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/pref/RemotePreferences.kt
@@ -58,18 +58,17 @@ object RemotePreferences : AnkoLogger {
     val timeSinceLastUpdate: DateTime get() = DateTime.now().minus(lastUpdatedMillis)
 
     // Booleans
-    val mapsEnabled: Boolean get() = remoteConfig.getBoolean("maps_enabled")
-    val rotationEnabled: Boolean get() = remoteConfig.getBoolean("rotation_enabled")
-    val nativeFursuitGames: Boolean get() = remoteConfig.getBoolean("native_fursuit_games")
-    val autoUpdateDisabled: Boolean get() = remoteConfig.getBoolean("auto_update_disabled")
+    val mapsEnabled: Boolean get() = remoteConfig.getBoolean("${BuildConfig.CONVENTION_IDENTIFIER}_maps_enabled")
+    val rotationEnabled: Boolean get() = remoteConfig.getBoolean("${BuildConfig.CONVENTION_IDENTIFIER}_rotation_enabled")
+    val nativeFursuitGames: Boolean get() = remoteConfig.getBoolean("${BuildConfig.CONVENTION_IDENTIFIER}_native_fursuit_games")
+    val autoUpdateDisabled: Boolean get() = remoteConfig.getBoolean("${BuildConfig.CONVENTION_IDENTIFIER}_auto_update_disabled")
 
     // Longs
-    val nextConStart: Long get() = remoteConfig.getLong("nextConStart")
-    val lastConEnd: Long get() = remoteConfig.getLong("lastConEnd")
+    val nextConStart: Long get() = remoteConfig.getLong("${BuildConfig.CONVENTION_IDENTIFIER}_nextConStart")
+    val lastConEnd: Long get() = remoteConfig.getLong("${BuildConfig.CONVENTION_IDENTIFIER}_lastConEnd")
 
     // Strings
-    val apiBaseUrl: String get() = remoteConfig.getString("api_base_url")
-    val supportChatUrl: String get() = remoteConfig.getString("support_chat_url")
-    val eventTitle: String get() = remoteConfig.getString("event_title")
-    val eventSubTitle: String get() = remoteConfig.getString("event_subtitle")
+    val supportChatUrl: String get() = remoteConfig.getString("${BuildConfig.CONVENTION_IDENTIFIER}_support_chat_url")
+    val eventTitle: String get() = remoteConfig.getString("${BuildConfig.CONVENTION_IDENTIFIER}_event_title")
+    val eventSubTitle: String get() = remoteConfig.getString("${BuildConfig.CONVENTION_IDENTIFIER}_event_subtitle")
 }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
@@ -27,6 +27,7 @@ import org.eurofurence.connavigator.tracking.Analytics
 import org.eurofurence.connavigator.util.extensions.booleans
 import org.eurofurence.connavigator.util.extensions.circleProgress
 import org.eurofurence.connavigator.util.extensions.localReceiver
+import org.eurofurence.connavigator.util.extensions.objects
 import org.eurofurence.connavigator.util.v2.compatAppearance
 import org.eurofurence.connavigator.util.v2.plus
 import org.eurofurence.connavigator.util.v2.thenNested
@@ -79,6 +80,19 @@ class ActivityStart : AppCompatActivity(), AnkoLogger, HasDb {
 
                 this@ActivityStart.startActivity(intentFor<ActivityRoot>())
             }
+        } else {
+            // If sync fails on the first start - we should tell the user why and exit afterwards.
+            runOnUiThread {
+                this@ActivityStart.alert(
+                        "${(it.objects["reason"] as Exception).message ?: ""}\n\nApplication will exit now.",
+                        "Retrieving data from server failed"
+                    )
+                {
+                    okButton { System.exit(1) }
+                    onCancelled { System.exit(1) }
+                }
+                .show()
+            }
         }
     }
 
@@ -89,7 +103,6 @@ class ActivityStart : AppCompatActivity(), AnkoLogger, HasDb {
             startActivity(intentFor<ActivityRoot>())
             return
         }
-
         info { "Starting start activity" }
 
         ui.setContentView(this)

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/ActivityStart.kt
@@ -122,7 +122,7 @@ class ActivityStart : AppCompatActivity(), AnkoLogger, HasDb {
         subscriptions += RemotePreferences.observer
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
-                    ui.remoteLastUpdatedText.text = "Remote configs was updated ${it.timeSinceLastUpdate.millis / 1000} seconds ago."
+                    ui.remoteLastUpdatedText.text = "Remote configs were updated ${it.timeSinceLastUpdate.millis / 1000} seconds ago."
                 }
 
         subscriptions += AnalyticsPreferences.observer
@@ -209,6 +209,7 @@ class StartUi : AnkoComponent<ActivityStart> {
     lateinit var startLayout: LinearLayout
     lateinit var loadingLayout: RelativeLayout
     lateinit var remoteLastUpdatedText: TextView
+    lateinit var versionIdentifierText: TextView
     lateinit var progressText: TextView
 
     lateinit var analyticalData: CheckBox
@@ -279,7 +280,13 @@ Is it okay to download the data now?
                         padding = dip(30)
                     }
 
-                    remoteLastUpdatedText = textView("Remote configs was updated ${RemotePreferences.timeSinceLastUpdate.millis / 1000} seconds ago.")
+                    remoteLastUpdatedText = textView("Remote configs were updated ${RemotePreferences.timeSinceLastUpdate.millis / 1000} seconds ago.") {
+                        textSize = 10F
+                    }
+
+                    versionIdentifierText = textView("Version ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) / ${BuildConfig.CONVENTION_IDENTIFIER}") {
+                        textSize = 10F
+                    }
                 }.lparams(matchParent, wrapContent)
             }.lparams(matchParent, wrapContent)
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuitCollected.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuitCollected.kt
@@ -33,7 +33,7 @@ class FragmentViewFursuitCollected : Fragment(), AnkoLogger {
                 invoker.addDefaultHeader("Authorization", AuthPreferences.asBearer())
             }
 
-            api.apiV2FursuitsCollectingGamePlayerParticipationGet()
+            api.apiFursuitsCollectingGamePlayerParticipationGet()
         } successUi {
             info { "successfully retrieved data!" }
             info { it }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuitGame.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewFursuitGame.kt
@@ -61,7 +61,7 @@ class FragmentViewFursuitGame : Fragment(), ContentAPI, HasDb, AnkoLogger {
                 invoker.addDefaultHeader("Authorization", AuthPreferences.asBearer())
             }
 
-            api.apiV2FursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tag)
+            api.apiFursuitsCollectingGamePlayerParticipationCollectTokenSafePost(tag)
         } successUi {
             info { "Successfully executed network request! Showing fursuit" }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMessageList.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/FragmentViewMessageList.kt
@@ -100,7 +100,7 @@ class FragmentViewMessageList : Fragment(), ContentAPI, AnkoLogger, HasDb, MainS
         } then {
             info { "Fetching messages" }
             apiService.communications.addHeader("Authorization", AuthPreferences.asBearer())
-            apiService.communications.apiV2CommunicationPrivateMessagesGet().sortedByDescending { it.createdDateTimeUtc }
+            apiService.communications.apiCommunicationPrivateMessagesGet().sortedByDescending { it.createdDateTimeUtc }
         } success {
             info("Successfully retrieved ${it.size} messages")
             this.messages = it

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/UserStatusFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/UserStatusFragment.kt
@@ -40,7 +40,7 @@ class UserStatusFragment : Fragment(), AnkoLogger {
         info { "Checking message counts" }
         apiService.communications.let {
             it.addHeader("Authorization", AuthPreferences.asBearer())
-            it.apiV2CommunicationPrivateMessagesGet()
+            it.apiCommunicationPrivateMessagesGet()
         }
     } successUi { messages ->
         context?.let {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
@@ -19,7 +19,7 @@ fun PrivateMessageRecord.markAsRead() {
         Log.i("PMR", "Marking message ${this.id} as read")
 
         apiService.communications.addHeader("Authorization", AuthPreferences.asBearer())
-        apiService.communications.apiV2CommunicationPrivateMessagesByMessageIdReadPost(this.id, true)
+        apiService.communications.apiCommunicationPrivateMessagesByMessageIdReadPost(this.id, true)
     } else {
         throw Exception("User is not logged in!")
     }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/webapi/ApiService.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/webapi/ApiService.kt
@@ -7,10 +7,9 @@ import com.android.volley.Network
 import com.android.volley.toolbox.BasicNetwork
 import com.android.volley.toolbox.DiskBasedCache
 import com.android.volley.toolbox.HurlStack
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.swagger.client.ApiInvoker
 import io.swagger.client.api.*
-import org.eurofurence.connavigator.pref.RemotePreferences
+import org.eurofurence.connavigator.BuildConfig
 import org.eurofurence.connavigator.util.extensions.catchHandle
 import org.jetbrains.anko.AnkoLogger
 import org.jetbrains.anko.debug
@@ -20,7 +19,7 @@ import java.io.File
  * The API services manage extended API functionality
  */
 object apiService : AnkoLogger {
-    var apiPath: String? = RemotePreferences.apiBaseUrl
+    var apiPath: String = "${BuildConfig.API_BASE_URL}/${BuildConfig.CONVENTION_IDENTIFIER}"
 
     val announcements by lazy { AnnouncementsApi().apply { basePath = apiPath } }
 
@@ -59,12 +58,6 @@ object apiService : AnkoLogger {
      */
     fun initialize(context: Context) {
         {
-            apiPath = RemotePreferences.apiBaseUrl
-
-            RemotePreferences.observer
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe { apiPath = it.apiBaseUrl }
-
             debug { "Initializing" }
 
             // Create the cache


### PR DESCRIPTION
- Moved `API_BASE_URL` to buildConfig (previously remote config).
- Added `CONVENTION_IDENTIFIER` to buildConfig
- Re-Generated Swagger Model (`apiV2*` is now `api*`)
- Updated FCM Subscription topics to `{CID}` and `{CID}-android` (previously `live-all` `live-android` / `test-all` `test-android` - we no longer need to distinguish between live/test since CID is the new selector)
- Updated FCM Device Registration topics to include `cid-{CID}`, removed `live` (because it's ambiguous)
- Updated `RemotePreferences` to prefix `{CID}_` to all keys
- UpdateIntent now fails when CID mismatches. Also shows toast for failure reason when triggered interactively.
- If initial update from first start (`ActivityStart`) fails, show dialog with reason and exit app.
- Added version & CID info to first start screen.