### PR TITLE
Show Toasts on Map

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 29
         versionCode 102
-        versionName "2.3.2"
+        versionName "2.3.3"
         multiDexEnabled true
 
         buildConfigField "String", "API_BASE_URL", '"https://app.eurofurence.org"'

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapItemFragment.kt
@@ -136,20 +136,19 @@ class MapFragment : Fragment(), HasDb, AnkoLogger {
                 }
             }
             LinkFragment.FragmentTypeEnum.EventConferenceRoom -> {
-                if (link.name !== null && !link.name.isEmpty()) {
-                    label = link.name
-                } else {
+                if (label.isNotBlank()) {
                     val eventConferenceRoom = db.rooms[UUID.fromString(link.target)]
                     if (eventConferenceRoom !== null) {
                         label = eventConferenceRoom.name
                     }
                 }
             }
+            else -> {}
         }
 
-        if (label !== null && !label.isEmpty()) {
+        if (label.isNotBlank()) {
             info { "Displaying tooltip for ${label} at (${tooltipX}, ${tooltipY})" }
-            // TODO: Display tooltip at link.target or
+            // TODO: Display actual tooltip at (tooltipX, tooltipY) instead of using a Toast
             toast(label)
         } else {
             info { "Failed to create label; skipping tooltip" }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapItemFragment.kt
@@ -69,22 +69,17 @@ class MapFragment : Fragment(), HasDb, AnkoLogger {
                 val y = (image.height ?: 0) * percentY
                 info { "Tap registered at x: $x, y: $y" }
 
-                val entries = mapRecord.findMatchingEntries(x, y)
+                val entry = mapRecord.findMatchingEntry(x, y)
 
-                info { "Found ${entries.size} entries" }
-
-                if (entries.isNotEmpty()) {
-                    val links = entries
-                            .flatMap { it.links.orEmpty() }
-                            .filter { it.fragmentType !== LinkFragment.FragmentTypeEnum.MapEntry }
-
-                    when (links.size) {
+                if (entry !== null) {
+                    info { "Found matching entry" }
+                    when (entry.links.size) {
                         0 -> Unit
-                        1 -> linkAction(links[0])
-                        else -> selector(getString(R.string.misc_find_out_more), links.map {
+                        1 -> linkAction(entry.links[0])
+                        else -> selector(getString(R.string.misc_find_out_more), entry.links.map {
                             it.name ?: getString(R.string.misc_link_no_name_provided)
                         }) { _, position ->
-                            linkAction(links[position])
+                            linkAction(entry.links[position])
                         }
                     }
                 }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
@@ -18,6 +18,16 @@ fun MapRecord.findMatchingEntries(x: Float, y: Float) =
                 .orEmpty()
                 .filter { (x - (it.x ?: 0) power 2F) + (y - (it.y ?: 0) power 2F) < (it.tapRadius ?: 0) power 2 }
 
+fun MapRecord.findMatchingEntry(x: Float, y: Float) =
+        findMatchingEntries(x,y)
+                .reduce { acc, mapEntryRecord -> if (mapEntryRecord.distance2(x,y) < acc.distance2(x,y)) mapEntryRecord else acc }
+
+fun MapEntryRecord.distance2(other: MapEntryRecord) =
+        ((x - other.x) power 2) + ((y - other.y) power 2)
+
+fun MapEntryRecord.distance2(otherX: Float, otherY: Float) =
+        ((x - otherX) power 2F) + ((y - otherY) power 2F)
+
 
 val ImageRecord.url: String get() = "${apiService.apiPath}/Api/Images/$id/Content/with-hash:${Base64.encodeToString(contentHashSha1.toByteArray(), Base64.NO_WRAP)}"
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
@@ -20,7 +20,8 @@ fun MapRecord.findMatchingEntries(x: Float, y: Float) =
 
 fun MapRecord.findMatchingEntry(x: Float, y: Float) =
         findMatchingEntries(x,y)
-                .reduce { acc, mapEntryRecord -> if (mapEntryRecord.distance2(x,y) < acc.distance2(x,y)) mapEntryRecord else acc }
+                .takeIf { it.isNotEmpty() }
+                ?.reduce { acc, mapEntryRecord -> if (mapEntryRecord.distance2(x,y) < acc.distance2(x,y)) mapEntryRecord else acc }
 
 fun MapEntryRecord.distance2(other: MapEntryRecord) =
         ((x - other.x) power 2) + ((y - other.y) power 2)

--- a/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/util/extensions/ModelExtensions.kt
@@ -23,9 +23,6 @@ fun MapRecord.findMatchingEntry(x: Float, y: Float) =
                 .takeIf { it.isNotEmpty() }
                 ?.reduce { acc, mapEntryRecord -> if (mapEntryRecord.distance2(x,y) < acc.distance2(x,y)) mapEntryRecord else acc }
 
-fun MapEntryRecord.distance2(other: MapEntryRecord) =
-        ((x - other.x) power 2) + ((y - other.y) power 2)
-
 fun MapEntryRecord.distance2(otherX: Float, otherY: Float) =
         ((x - otherX) power 2F) + ((y - otherY) power 2F)
 

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -12,5 +12,6 @@
         <item name="colorAccent">@color/accent</item>
         <item name="android:colorForeground">@color/textBlack</item>
         <item name="android:statusBarColor">@color/primaryDarker</item>
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,13 +12,13 @@
     <color name="accent">#47A0DF</color>
     <color name="accentDark">#258BD3</color>
     <color name="accentDarker">#0976C3</color>
-    <color name="textWhite">#dcdcdc</color>
+    <color name="textWhite">#fff</color>
     <color name="textBlack">#010101</color>
     <color name="backgroundGrey">#DDD</color>
     <color name="mutedText">#999</color>
     <color name="alert">#FFE082</color>
     <color name="iconColor">#666</color>
-    <color name="hamburgerColor">#FFF</color>
+    <color name="hamburgerColor">@color/textWhite</color>
     <color name="darkBackground">#FF424242</color>
     <color name="lightBackground">#FFFFFFFF</color>
     <color name="error">#B02020</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="mutedText">#999</color>
     <color name="alert">#FFE082</color>
     <color name="iconColor">#666</color>
+    <color name="hamburgerColor">#FFF</color>
     <color name="darkBackground">#FF424242</color>
     <color name="lightBackground">#FFFFFFFF</color>
     <color name="error">#B02020</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="colorAccent">@color/accent</item>
         <item name="android:colorForeground">@color/textBlack</item>
-        <item name="drawerArrowStyle">@style/DrawerHamburgerStyle</item>
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
@@ -49,9 +49,9 @@
         <item name="android:colorForeground">@color/textBlack</item>
     </style>
 
-    <style name="DrawerHamburgerStyle" parent="@style/Widget.AppCompat.DrawerArrowToggle">
+    <style name="DrawerArrowStyle" parent="@style/Widget.AppCompat.DrawerArrowToggle">
         <item name="spinBars">true</item>
-        <item name="color">@color/iconColor</item>
+        <item name="color">@color/hamburgerColor</item>
     </style>
 
 </resources>


### PR DESCRIPTION
* Changed tapping behaviour from matching multiple, overlapping map entries to using only the nearest, matching neighbour.
* Show short Toast when tapping a map entry with links of type MapEntry or EventConferenceRoom

No actual tooltips at the tapped location, but may still be considered a valid way to close #310.