### PR TITLE
Update the FAB on Event Details

### DIFF
--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
@@ -19,9 +19,11 @@ import org.jetbrains.anko.*
 /**
  * Shows an event dialog
  */
-fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
+fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db, favoriteCallback: ((Boolean) -> Unit)? = null) {
+    val isFavorite = db.faves.contains(event.id)
+
     val options = listOf(
-            if (!db.faves.contains(event.id)) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites),
+            if (!isFavorite) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites),
             context.getString(R.string.event_share_export_to_calendar),
             context.getString(R.string.event_share_event)
     )
@@ -34,7 +36,7 @@ fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
             0 -> {
                 debug { "Favouriting event for user" }
                 context.sendBroadcast(IntentFor<EventFavoriteBroadcast>(context).apply { jsonObjects["event"] = event })
-
+                favoriteCallback?.invoke(!isFavorite)
                 context.toast(context.getString(R.string.event_changed_status))
             }
             1 -> {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
@@ -21,8 +21,7 @@ import org.jetbrains.anko.*
  */
 fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
     val options = listOf(
-            // TODO: Re-enable once EventItemFragment can properly react to model changes
-//            if (!db.faves.contains(event.id)) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites)
+            if (!db.faves.contains(event.id)) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites),
             context.getString(R.string.event_share_export_to_calendar),
             context.getString(R.string.event_share_event)
     )
@@ -32,14 +31,13 @@ fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
             options
     ) { _, position ->
         when (position) {
-//            0 -> {
-//                debug { "Favouriting event for user" }
-//                context.sendBroadcast(IntentFor<EventFavoriteBroadcast>(context).apply { jsonObjects["event"] = event })
-//
-//                context.toast(context.getString(R.string.event_changed_status))
-//            }
             0 -> {
-//            1 -> {
+                debug { "Favouriting event for user" }
+                context.sendBroadcast(IntentFor<EventFavoriteBroadcast>(context).apply { jsonObjects["event"] = event })
+
+                context.toast(context.getString(R.string.event_changed_status))
+            }
+            1 -> {
                 debug { "Writing event to calendar" }
 
                 val calendarIntent = Intent(Intent.ACTION_INSERT)
@@ -56,8 +54,7 @@ fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
 
                 startActivity(context, calendarIntent, null)
             }
-            1 -> {
-//            2 -> {
+            2 -> {
                 debug { "Sharing event" }
 
                 AnalyticsService.event(AnalyticsService.Category.EVENT, AnalyticsService.Action.SHARED, event.title)

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/dialogs/EventDialog.kt
@@ -21,7 +21,8 @@ import org.jetbrains.anko.*
  */
 fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
     val options = listOf(
-            if (!db.faves.contains(event.id)) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites),
+            // TODO: Re-enable once EventItemFragment can properly react to model changes
+//            if (!db.faves.contains(event.id)) context.getString(R.string.event_add_to_favorites) else context.getString(R.string.event_remove_from_favorites)
             context.getString(R.string.event_share_export_to_calendar),
             context.getString(R.string.event_share_event)
     )
@@ -31,13 +32,14 @@ fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
             options
     ) { _, position ->
         when (position) {
+//            0 -> {
+//                debug { "Favouriting event for user" }
+//                context.sendBroadcast(IntentFor<EventFavoriteBroadcast>(context).apply { jsonObjects["event"] = event })
+//
+//                context.toast(context.getString(R.string.event_changed_status))
+//            }
             0 -> {
-                debug { "Favouriting event for user" }
-                context.sendBroadcast(IntentFor<EventFavoriteBroadcast>(context).apply { jsonObjects["event"] = event })
-
-                context.toast(context.getString(R.string.event_changed_status))
-            }
-            1 -> {
+//            1 -> {
                 debug { "Writing event to calendar" }
 
                 val calendarIntent = Intent(Intent.ACTION_INSERT)
@@ -54,7 +56,8 @@ fun AnkoLogger.eventDialog(context: Context, event: EventRecord, db: Db) {
 
                 startActivity(context, calendarIntent, null)
             }
-            2 -> {
+            1 -> {
+//            2 -> {
                 debug { "Sharing event" }
 
                 AnalyticsService.event(AnalyticsService.Category.EVENT, AnalyticsService.Action.SHARED, event.title)

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
@@ -202,10 +202,10 @@ class EventItemFragment : Fragment(), HasDb, AnkoLogger {
     private fun setFabIconState(isFavorite: Boolean) {
         info("Updating icon of FAB for $eventId")
         if (isFavorite) {
-            ui.favoriteButton.setImageDrawable(context?.createFADrawable(R.string.fa_heartbeat_solid))
+            ui.favoriteButton.setImageDrawable(context?.createFADrawable(R.string.fa_heart, true))
             ui.favoriteButton.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.accent))
         } else {
-            ui.favoriteButton.setImageDrawable(context?.createFADrawable(R.string.fa_heart))
+            ui.favoriteButton.setImageDrawable(context?.createFADrawable(R.string.fa_heart, false))
             ui.favoriteButton.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.primaryLight))
         }
     }

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
@@ -180,7 +180,7 @@ class EventItemFragment : Fragment(), HasDb, AnkoLogger {
 
     private fun showDialog(event: EventRecord) {
         context?.let {
-            eventDialog(it, event, db)
+            eventDialog(it, event, db) { isFavorite -> setFabIconState(isFavorite) }
         }
     }
 
@@ -199,9 +199,9 @@ class EventItemFragment : Fragment(), HasDb, AnkoLogger {
     /**
      * Changes the FAB based on if the current event is liked or not
      */
-    private fun setFabIconState(isFavorited: Boolean) {
-        info("Updating icon of FAB for ${eventId}")
-        if (isFavorited) {
+    private fun setFabIconState(isFavorite: Boolean) {
+        info("Updating icon of FAB for $eventId")
+        if (isFavorite) {
             ui.favoriteButton.setImageDrawable(context?.createFADrawable(R.string.fa_heartbeat_solid))
             ui.favoriteButton.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.accent))
         } else {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventRecyclerFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventRecyclerFragment.kt
@@ -288,7 +288,7 @@ class EventRecyclerFragment : Fragment(), HasDb, AnkoLogger {
                 isLongClickable = true
                 setOnLongClickListener {
                     context?.apply {
-                        eventDialog(this, record, db)
+                        eventDialog(this, record, db) { dataUpdated() }
                     }
                     true
                 }


### PR DESCRIPTION
When the user taps the FAB on the event details to toggle an event's status as favourite, the button should immediately reflect the resulting model change. Due to current architectural constraints, the process which changes this state uses its own RootDb instance, circumventing the subscription by the fragment to changes on its own instance, thus requiring the ui to proactively predict which state the model will be in, provided the action triggered by the user interaction will be persisted successfully.

It's not a nice solution, but for the time being, I'd file it under #WorksForMe, especially since a proper fix would probably require major restructuring.