### PR TITLE
Adding app status fragment (for api state support)

### DIFF
--- a/app/src/main/java/io/swagger/client/model/AggregatedDeltaResponse.java
+++ b/app/src/main/java/io/swagger/client/model/AggregatedDeltaResponse.java
@@ -18,9 +18,11 @@ import com.google.gson.annotations.SerializedName;
 
 @ApiModel(description = "")
 public class AggregatedDeltaResponse  {
-  
+
   @SerializedName("ConventionIdentifier")
   private String conventionIdentifier = null;
+  @SerializedName("State")
+  private String state = null;
   @SerializedName("Since")
   private Date since = null;
   @SerializedName("CurrentDateTimeUtc")
@@ -54,6 +56,16 @@ public class AggregatedDeltaResponse  {
   }
   public void setConventionIdentifier(String conventionIdentifier) {
     this.conventionIdentifier = conventionIdentifier;
+  }
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  public String getState() {
+    return state;
+  }
+  public void setState(String state) {
+    this.state = state;
   }
 
   /**
@@ -187,6 +199,7 @@ public class AggregatedDeltaResponse  {
     }
     AggregatedDeltaResponse aggregatedDeltaResponse = (AggregatedDeltaResponse) o;
     return (conventionIdentifier == null ? aggregatedDeltaResponse.conventionIdentifier == null : conventionIdentifier.equals(aggregatedDeltaResponse.conventionIdentifier)) &&
+        (state == null ? aggregatedDeltaResponse.state == null : state.equals(aggregatedDeltaResponse.state)) &&
         (since == null ? aggregatedDeltaResponse.since == null : since.equals(aggregatedDeltaResponse.since)) &&
         (currentDateTimeUtc == null ? aggregatedDeltaResponse.currentDateTimeUtc == null : currentDateTimeUtc.equals(aggregatedDeltaResponse.currentDateTimeUtc)) &&
         (events == null ? aggregatedDeltaResponse.events == null : events.equals(aggregatedDeltaResponse.events)) &&
@@ -205,6 +218,7 @@ public class AggregatedDeltaResponse  {
   public int hashCode() {
     int result = 17;
     result = 31 * result + (conventionIdentifier == null ? 0: conventionIdentifier.hashCode());
+    result = 31 * result + (state == null ? 0: state.hashCode());
     result = 31 * result + (since == null ? 0: since.hashCode());
     result = 31 * result + (currentDateTimeUtc == null ? 0: currentDateTimeUtc.hashCode());
     result = 31 * result + (events == null ? 0: events.hashCode());
@@ -224,8 +238,9 @@ public class AggregatedDeltaResponse  {
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class AggregatedDeltaResponse {\n");
-    
+
     sb.append("  conventionIdentifier: ").append(conventionIdentifier).append("\n");
+    sb.append("  state: ").append(state).append("\n");
     sb.append("  since: ").append(since).append("\n");
     sb.append("  currentDateTimeUtc: ").append(currentDateTimeUtc).append("\n");
     sb.append("  events: ").append(events).append("\n");

--- a/app/src/main/kotlin/org/eurofurence/connavigator/database/Db.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/database/Db.kt
@@ -37,6 +37,11 @@ interface Db {
     var version: String?
 
     /**
+     * Stored state.
+     */
+    var state: String?
+
+    /**
      * Database for [AnnouncementRecord].
      */
     val announcements: StoredSource<AnnouncementRecord>
@@ -193,6 +198,12 @@ interface HasDb : Db {
             db.version = value
         }
 
+    override var state: String?
+        get() = db.state
+        set(value) {
+            db.state = value
+        }
+
     override val announcements: StoredSource<AnnouncementRecord>
         get() = db.announcements
 
@@ -280,6 +291,8 @@ class RootDb(context: Context) : Stored(context), Db {
 
     override var version by storedValue<String>()
 
+    override var state by storedValue<String>()
+
     override val announcements = storedSource(AnnouncementRecord::getId)
 
     override val dealers = storedSource(DealerRecord::getId)
@@ -345,6 +358,7 @@ class RootDb(context: Context) : Stored(context), Db {
 
     override fun clear() {
         date = null
+        state = null
         announcements.delete()
         dealers.delete()
         days.delete()

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/activities/NavActivity.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/activities/NavActivity.kt
@@ -33,7 +33,6 @@ import org.eurofurence.connavigator.preferences.AuthPreferences
 import org.eurofurence.connavigator.preferences.BackgroundPreferences
 import org.eurofurence.connavigator.preferences.RemotePreferences
 import org.eurofurence.connavigator.services.AnalyticsService
-import org.eurofurence.connavigator.ui.fragments.HomeFragmentDirections
 import org.eurofurence.connavigator.util.DatetimeProxy
 import org.eurofurence.connavigator.util.extensions.setFAIcon
 import org.eurofurence.connavigator.util.v2.plus
@@ -205,6 +204,12 @@ class NavActivity : AppCompatActivity(), NavHost, AnkoLogger, HasDb {
         }
 
         super.onResume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        subscriptions.dispose()
+        subscriptions = Disposables.empty()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AnnouncementItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AnnouncementItemFragment.kt
@@ -31,14 +31,13 @@ import org.joda.time.DateTime
 import us.feras.mdv.MarkdownView
 import java.util.*
 
-class AnnouncementItemFragment : Fragment(), HasDb, AnkoLogger {
+class AnnouncementItemFragment : DisposingFragment(), HasDb, AnkoLogger {
     private val args: AnnouncementItemFragmentArgs by navArgs()
     private val announcementId by lazy { UUID.fromString(args.announcementId) }
 
     override val db by lazyLocateDb()
 
     val ui = AnnouncementItemUi()
-    var subscriptions = Disposables.empty()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
@@ -52,7 +51,7 @@ class AnnouncementItemFragment : Fragment(), HasDb, AnkoLogger {
             findNavController().popBackStack()
         }
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             val announcement = it.announcements[announcementId]
             if (announcement != null) {
                 info { "Updating announcement item" }
@@ -78,12 +77,7 @@ class AnnouncementItemFragment : Fragment(), HasDb, AnkoLogger {
                     View.GONE
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        .collectOnDestroyView()
     }
 }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AnnouncementListFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AnnouncementListFragment.kt
@@ -28,7 +28,7 @@ import org.eurofurence.connavigator.util.v2.plus
 import org.jetbrains.anko.*
 import org.jetbrains.anko.support.v4.UI
 
-class AnnouncementListFragment : Fragment(), HasDb, AnkoLogger {
+class AnnouncementListFragment : DisposingFragment(), HasDb, AnkoLogger {
     inner class AnnouncementDataholder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val layout: LinearLayout by view()
         val announcementTitle: TextView by view()
@@ -65,8 +65,6 @@ class AnnouncementListFragment : Fragment(), HasDb, AnkoLogger {
 
     override val db by lazyLocateDb()
 
-    var subscriptions = Disposables.empty()
-
     val ui = AnnouncementsUi()
     private val announcementAdapter by lazy { AnnoucementRecyclerDataAdapter() }
 
@@ -82,18 +80,13 @@ class AnnouncementListFragment : Fragment(), HasDb, AnkoLogger {
             itemAnimator = DefaultItemAnimator()
         }
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             info { "Updating items in announcement recycler" }
             ui.layout.visibility = if (getAnnouncements().count() == 0) View.GONE else View.VISIBLE
             announcementAdapter.announcements = getAnnouncements()
             announcementAdapter.notifyDataSetChanged()
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        .collectOnDestroyView()
     }
 
     private fun getAnnouncements() = db.announcements.items

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AppStatusFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AppStatusFragment.kt
@@ -1,0 +1,98 @@
+package org.eurofurence.connavigator.ui.fragments
+
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import io.reactivex.disposables.Disposables
+import org.eurofurence.connavigator.R
+import org.eurofurence.connavigator.database.HasDb
+import org.eurofurence.connavigator.database.lazyLocateDb
+import org.eurofurence.connavigator.util.extensions.fontAwesomeView
+import org.eurofurence.connavigator.util.v2.compatAppearance
+import org.eurofurence.connavigator.util.v2.plus
+import org.jetbrains.anko.*
+import org.jetbrains.anko.support.v4.UI
+
+class AppStatusFragment : Fragment(), HasDb {
+    val ui = AppStatusUi()
+    var subscriptions = Disposables.empty()
+    override val db by lazyLocateDb()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
+            UI { ui.createView(this) }.view
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        subscriptions += db.subscribe {
+
+            val state = it.state
+            if (state == null || state.toLowerCase() == "live") {
+                ui.layout.visibility = View.GONE
+            } else {
+                ui.layout.visibility = View.VISIBLE
+
+                if (state.toLowerCase() == "past") {
+                    ui.stateText.textResource = R.string.app_state_past
+                    ui.stateLayout.backgroundColor = ContextCompat.getColor(context!!, R.color.errorBackground);
+                }
+                if (state.toLowerCase() == "preview") {
+                    ui.stateText.textResource = R.string.app_state_preview
+                    ui.stateLayout.backgroundColor = ContextCompat.getColor(context!!, R.color.warningBackground);
+                }
+            }
+        }
+    }
+}
+
+class AppStatusUi : AnkoComponent<Fragment> {
+    lateinit var stateLayout: LinearLayout
+    lateinit var stateText: TextView
+    lateinit var layout: ViewGroup
+
+    override fun createView(ui: AnkoContext<Fragment>) = with(ui) {
+        scrollView {
+            this@AppStatusUi.layout = this
+            lparams(matchParent, matchParent)
+            backgroundResource = R.color.lightBackground
+
+            verticalLayout {
+
+                stateLayout = linearLayout {
+                    lparams(matchParent, wrapContent) {
+                        setPadding(0, dip(20), 0, dip(20))
+                    }
+
+                    weightSum = 100f
+
+                    fontAwesomeView {
+                        text = "{fa-warning 30sp}"
+                        textColor = ContextCompat.getColor(context, R.color.textBlack)
+                        lparams(dip(0), matchParent, 15F)
+                        gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                    }
+
+                    verticalLayout {
+                        stateText = textView {
+                            textResource = R.string.misc_version
+                            compatAppearance = android.R.style.TextAppearance_Small
+                            textColor = ContextCompat.getColor(context, R.color.textBlack)
+                        }
+
+                    }.lparams(dip(0), wrapContent) {
+                        weight = 75F
+                    }
+
+                }.lparams(matchParent, wrapContent) {
+                    topMargin = dip(20)
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AppStatusFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/AppStatusFragment.kt
@@ -19,17 +19,15 @@ import org.eurofurence.connavigator.util.v2.plus
 import org.jetbrains.anko.*
 import org.jetbrains.anko.support.v4.UI
 
-class AppStatusFragment : Fragment(), HasDb {
+class AppStatusFragment : DisposingFragment(), HasDb {
     val ui = AppStatusUi()
-    var subscriptions = Disposables.empty()
     override val db by lazyLocateDb()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-
-        subscriptions += db.subscribe {
+        db.subscribe {
 
             val state = it.state
             if (state == null || state.toLowerCase() == "live") {
@@ -46,7 +44,7 @@ class AppStatusFragment : Fragment(), HasDb {
                     ui.stateLayout.backgroundColor = ContextCompat.getColor(context!!, R.color.warningBackground);
                 }
             }
-        }
+        }.collectOnDestroyView()
     }
 }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/DealerItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/DealerItemFragment.kt
@@ -44,12 +44,11 @@ import org.jetbrains.anko.support.v4.browse
 import org.jetbrains.anko.support.v4.px2dip
 import java.util.*
 
-class DealerItemFragment : Fragment(), HasDb, AnkoLogger {
+class DealerItemFragment : DisposingFragment(), HasDb, AnkoLogger {
     private val args: DealerItemFragmentArgs by navArgs()
     private val dealerId by lazy { UUID.fromString(args.dealerId) }
 
     val ui by lazy { DealerUi() }
-    var subscriptions = Disposables.empty()
 
     override val db by lazyLocateDb()
 
@@ -63,15 +62,10 @@ class DealerItemFragment : Fragment(), HasDb, AnkoLogger {
             findNavController().popBackStack()
         }
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             fillUi()
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        .collectOnDestroyView()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventItemFragment.kt
@@ -48,10 +48,9 @@ import java.util.*
 /**
  * Created by David on 4/9/2016.
  */
-class EventItemFragment : Fragment(), HasDb, AnkoLogger {
+class EventItemFragment : DisposingFragment(), HasDb, AnkoLogger {
     override val db by lazyLocateDb()
     val args: EventItemFragmentArgs by navArgs()
-    var subscriptions = Disposables.empty()
     val eventId by lazy { UUID.fromString(args.eventId) }
     val ui by lazy { EventUi() }
 
@@ -69,15 +68,9 @@ class EventItemFragment : Fragment(), HasDb, AnkoLogger {
             findNavController().popBackStack()
         }
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             fillUi(savedInstanceState)
-        }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        }.collectOnDestroyView()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventRecyclerFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/EventRecyclerFragment.kt
@@ -47,12 +47,8 @@ import org.joda.time.Minutes
  * Event view recycler to hold the viewpager items
  * TODO: Refactor the everliving fuck out of this shitty software
  */
-class EventRecyclerFragment : Fragment(), HasDb, AnkoLogger {
-    //private val results = ArrayList<EventRecord>()
-
+class EventRecyclerFragment : DisposingFragment(), HasDb, AnkoLogger {
     override val db by lazyLocateDb()
-
-    var subscriptions = Disposables.empty()
 
     val ui by lazy { EventListView() }
 
@@ -319,7 +315,7 @@ class EventRecyclerFragment : Fragment(), HasDb, AnkoLogger {
         configureTitle()
 
         // Filter the data
-        subscriptions += db.subscribe { dataUpdated() }
+        db.subscribe { dataUpdated() }.collectOnDestroyView()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -338,12 +334,6 @@ class EventRecyclerFragment : Fragment(), HasDb, AnkoLogger {
                         ?.let(lm::onRestoreInstanceState)
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
     }
 
     private fun configureTitle() {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/HomeFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/HomeFragment.kt
@@ -62,6 +62,7 @@ class HomeFragment : Fragment(), AnkoLogger, HasDb {
     private val announcement by lazy { AnnouncementListFragment() }
     private val userStatus by lazy { UserStatusFragment() }
     private val loadingWidget by lazy { LoadingIndicatorFragment() }
+    private val appStatus by lazy { AppStatusFragment() }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
@@ -107,6 +108,7 @@ class HomeFragment : Fragment(), AnkoLogger, HasDb {
                 .replace(R.id.home_favorited, favorited)
                 .replace(R.id.home_announcement, announcement)
                 .replace(R.id.home_user_status, userStatus)
+                .replace(R.id.appStatusWidget, appStatus)
                 .commitAllowingStateLoss()
     }
 
@@ -140,6 +142,7 @@ class HomeUi : AnkoComponent<Fragment> {
     private lateinit var favoritesFragment: ViewGroup
     private lateinit var announcementFragment: ViewGroup
     private lateinit var loginWidget: ViewGroup
+    private lateinit var appStatusWidget: ViewGroup
     private lateinit var loadingWidget: FrameLayout
 
     @SuppressLint("ResourceType")
@@ -159,9 +162,17 @@ class HomeUi : AnkoComponent<Fragment> {
                     setMargins(0, 0, 0, 0)
                 }
 
+                appStatusWidget = frameLayout {
+                    id = R.id.appStatusWidget
+                }
+
                 loadingWidget = frameLayout {
                     id = R.id.loadingWidget
                 }
+
+                currentFragment = linearLayout {
+                    id = R.id.home_upcoming
+                }.lparams(matchParent, wrapContent)
 
                 loginWidget = linearLayout {
                     id = R.id.home_user_status

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoGroupFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoGroupFragment.kt
@@ -31,7 +31,7 @@ import java.util.*
 /**
  * Renders an info group element and displays it's individual items
  */
-class InfoGroupFragment : Fragment(), HasDb, AnkoLogger {
+class InfoGroupFragment : DisposingFragment(), HasDb, AnkoLogger {
     inner class InfoItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val layout: LinearLayout by view("layout")
         val name: TextView by view("title")
@@ -73,8 +73,6 @@ class InfoGroupFragment : Fragment(), HasDb, AnkoLogger {
 
     val ui = InfoGroupUi()
 
-    var subscriptions = Disposables.empty()
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
 
@@ -83,9 +81,10 @@ class InfoGroupFragment : Fragment(), HasDb, AnkoLogger {
 
         fillUi()
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             fillUi()
         }
+        .collectOnDestroyView()
     }
 
     private fun fillUi() {
@@ -107,12 +106,6 @@ class InfoGroupFragment : Fragment(), HasDb, AnkoLogger {
                 groupLayout.visibility = View.GONE
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
     }
 
     private fun setDropdown() {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoItemFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoItemFragment.kt
@@ -37,9 +37,8 @@ import java.util.*
 /**
  * Views an info based on an ID passed to the intent
  */
-class InfoItemFragment : Fragment(), HasDb {
+class InfoItemFragment : DisposingFragment(), HasDb {
     val ui by lazy { InfoUi() }
-    var subscriptions = Disposables.empty()
     private val args: InfoItemFragmentArgs by navArgs()
     private val infoId: UUID? by lazy { UUID.fromString(args.itemId) }
     override val db by lazyLocateDb()
@@ -51,13 +50,7 @@ class InfoItemFragment : Fragment(), HasDb {
         super.onViewCreated(view, savedInstanceState)
 
         fillUi()
-        subscriptions += db.subscribe { fillUi() }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        db.subscribe { fillUi() }.collectOnDestroyView()
     }
 
     private fun fillUi() {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoListFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/InfoListFragment.kt
@@ -19,11 +19,9 @@ import org.jetbrains.anko.support.v4.withArguments
 // TODO req: fix build
 // TODO req: add state saving
 
-class InfoListFragment : Fragment(), HasDb{
+class InfoListFragment : DisposingFragment(), HasDb{
     override val db by lazyLocateDb()
     val ui = ViewInfoGroupsUi()
-
-    var subscriptions = Disposables.empty()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
@@ -32,9 +30,10 @@ class InfoListFragment : Fragment(), HasDb{
         super.onViewCreated(view, savedInstanceState)
 
         fillUi()
-        subscriptions += db.subscribe {
+        db.subscribe {
             fillUi()
         }
+        .collectOnDestroyView()
     }
 
     private fun fillUi() {
@@ -54,12 +53,6 @@ class InfoListFragment : Fragment(), HasDb{
                 .forEach { transaction.add(R.id.info_group_container, it.first, it.second) }
 
         transaction.commit()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
     }
 }
 

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/LoadingIndicatorFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/LoadingIndicatorFragment.kt
@@ -26,26 +26,22 @@ import org.eurofurence.connavigator.workers.PreloadImageWorker
 import org.jetbrains.anko.*
 import org.jetbrains.anko.support.v4.UI
 
-class LoadingIndicatorFragment : Fragment(), AnkoLogger {
+class LoadingIndicatorFragment : DisposingFragment(), AnkoLogger {
     val ui = LoadingIndicatorFragmentUi()
-    var subscriptions = Disposables.empty()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
             UI { ui.createView(this) }.view
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-    }
-
     override fun onStart() {
         ui.quitButton.setOnClickListener { activity?.finish() }
 
-        subscriptions += BackgroundPreferences
+        BackgroundPreferences
                 .observer
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     manageUI()
                 }
+                .collectOnDestroyView()
 
         manageUI()
 
@@ -70,12 +66,6 @@ class LoadingIndicatorFragment : Fragment(), AnkoLogger {
         }
 
         super.onStart()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
     }
 
     private fun manageUI() = when (BackgroundPreferences.loadingState) {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapDetailFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/MapDetailFragment.kt
@@ -32,13 +32,12 @@ import org.jetbrains.anko.support.v4.UI
 import org.jetbrains.anko.support.v4.px2dip
 import java.util.*
 
-class MapDetailFragment : Fragment(), HasDb, AnkoLogger {
+class MapDetailFragment : DisposingFragment(), HasDb, AnkoLogger {
     override val db by lazyLocateDb()
 
     val ui by lazy { MapDetailUi() }
     val id get() = arguments?.getString("id") ?: ""
     val showTitle get() = arguments!!.getBoolean("showTitle")
-    var subscriptions = Disposables.empty()
     private var linkFound = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
@@ -47,16 +46,11 @@ class MapDetailFragment : Fragment(), HasDb, AnkoLogger {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        subscriptions += db.subscribe {
+        db.subscribe {
             ui.title.visibility = if (showTitle) View.VISIBLE else View.GONE
             findLinkFragment()
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        subscriptions.dispose()
-        subscriptions = Disposables.empty()
+        .collectOnDestroyView()
     }
 
     fun withArguments(id: UUID?, showTitle: Boolean = false) = apply {

--- a/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/UserStatusFragment.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/ui/fragments/UserStatusFragment.kt
@@ -30,7 +30,6 @@ import java.util.*
 
 class UserStatusFragment : DisposingFragment(), AnkoLogger, HasDb {
     val ui = UserStatusUi()
-    var subscriptions = Disposables.empty()
     override val db by lazyLocateDb()
 
 
@@ -49,7 +48,7 @@ class UserStatusFragment : DisposingFragment(), AnkoLogger, HasDb {
     }
 
     private fun subscribeToDatabase() {
-        subscriptions += db.subscribe {
+        db.subscribe {
             val state = it.state
             val canLogin = state != null && state.toLowerCase() != "past"
 
@@ -57,6 +56,7 @@ class UserStatusFragment : DisposingFragment(), AnkoLogger, HasDb {
                 layout.visibility = if (canLogin) View.VISIBLE else View.GONE
             }
         }
+        .collectOnDestroyView()
     }
 
     /**

--- a/app/src/main/kotlin/org/eurofurence/connavigator/workers/DataUpdateWorker.kt
+++ b/app/src/main/kotlin/org/eurofurence/connavigator/workers/DataUpdateWorker.kt
@@ -110,6 +110,8 @@ class DataUpdateWorker(context: Context, workerParams: WorkerParameters) : Worke
         db.knowledgeEntries.apply(sync.knowledgeEntries.convert())
         db.knowledgeGroups.apply(sync.knowledgeGroups.convert())
         db.maps.apply(sync.maps.convert())
+        db.state = sync.state;
+
 
         // Reconcile events with favorites
         db.faves = db.events.items.map { it.id }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -22,6 +22,8 @@
     <color name="darkBackground">#FF424242</color>
     <color name="lightBackground">#FFFFFFFF</color>
     <color name="error">#B02020</color>
+    <color name="errorBackground">#FF9999</color>
+    <color name="warningBackground">#FFDD99</color>
     <color name="favorite">#f44336</color>
     <color name="sponsor">#fbc02d</color>
     <color name="supersponsor">#673ab7</color>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -46,4 +46,5 @@
     <item name="navTitle" type="id" />
     <item name="navSubTitle" type="id" />
     <item name="loadingWidget" type="id" />
+    <item name="appStatusWidget" type="id" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,9 @@
     <string name="misc_version_code">Version Code: %1$d</string>
     <string name="misc_version_detailed">Version %1$s (%2$d) / %3$s </string>
 
+    <string name="app_state_past">You\'re using an app version that connects to data of a past convention.\n\nAn updated version will be available several weeks before the next convention start date.\n\nLogging in with current credentials/registration details will not work.</string>
+    <string name="app_state_preview">You\'re using an app version that connects to preview data of an upcoming convention.\n\nPlease do not share any content and treat it as unofficial &amp; confidential.</string>
+
     <string name="misc_working_please_wait">Working&#8230; Please wait!</string>
     <string name="misc_android_developers">Android Developers</string>
 


### PR DESCRIPTION
- Adding `state` property on /Sync endpoint to Model
- Storing/Updating `state` in Db in sync calls
- Adding **AppStatusFragment** that shows on state `past` and `preview`
- Updating **UserStatusFragemnt** to default to 'hidden', and only show when app state different than `past` has been retrieved.